### PR TITLE
Add remaining open-source compliance artifacts

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 name: DCO
 
 on:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,24 @@ Thank you for your interest in contributing to the NemoClaw Community ecosystem.
 - **Documentation** -- Improve READMEs, guides, and usage examples
 - **Integrations** -- Connect NemoClaw to new tools, platforms, or workflows
 
+## Developer Certificate of Origin (DCO)
+
+All contributions to this project must include a `Signed-off-by` line in the commit message, certifying that you wrote or have the right to submit the code under the project's open-source license. This is the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
+
+Add the sign-off automatically with `git commit -s`:
+
+```bash
+git commit -s -m "Add new sandbox image"
+```
+
+This appends a line like:
+
+```
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+A DCO check runs on every pull request and will fail if any commit is missing the sign-off.
+
 ## Getting Started
 
 1. Fork this repository

--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -1,0 +1,144 @@
+THIRD-PARTY SOFTWARE NOTICES
+
+This file lists the third-party software packages used by NemoClaw Community,
+along with their respective licenses.
+
+================================================================================
+Docker Base Images
+================================================================================
+
+Image: ubuntu:24.04
+License: Various (see https://ubuntu.com/legal/intellectual-property-policy)
+URL: https://hub.docker.com/_/ubuntu
+
+Image: ghcr.io/astral-sh/uv:latest
+License: Apache-2.0 OR MIT
+URL: https://github.com/astral-sh/uv
+
+Image: docker/dockerfile:1.4 (BuildKit frontend)
+License: Apache-2.0
+URL: https://github.com/moby/buildkit
+
+================================================================================
+System Packages (APT — Ubuntu 24.04)
+================================================================================
+
+Package: build-essential
+License: GPL-2.0+
+URL: https://packages.ubuntu.com/noble/build-essential
+
+Package: ca-certificates
+License: GPL-2.0+
+URL: https://packages.ubuntu.com/noble/ca-certificates
+
+Package: curl
+License: MIT
+URL: https://packages.ubuntu.com/noble/curl
+
+Package: dnsutils
+License: MPL-2.0
+URL: https://packages.ubuntu.com/noble/dnsutils
+
+Package: gh (GitHub CLI)
+License: MIT
+URL: https://github.com/cli/cli
+
+Package: git
+License: GPL-2.0
+URL: https://packages.ubuntu.com/noble/git
+
+Package: iproute2
+License: GPL-2.0
+URL: https://packages.ubuntu.com/noble/iproute2
+
+Package: iputils-ping
+License: BSD-3-Clause
+URL: https://packages.ubuntu.com/noble/iputils-ping
+
+Package: nano
+License: GPL-3.0
+URL: https://packages.ubuntu.com/noble/nano
+
+Package: net-tools
+License: GPL-2.0+
+URL: https://packages.ubuntu.com/noble/net-tools
+
+Package: netcat-openbsd
+License: BSD-2-Clause
+URL: https://packages.ubuntu.com/noble/netcat-openbsd
+
+Package: nodejs (22.x via NodeSource)
+License: MIT
+URL: https://github.com/nodejs/node
+
+Package: python3
+License: PSF-2.0
+URL: https://packages.ubuntu.com/noble/python3
+
+Package: python3-pip
+License: MIT
+URL: https://packages.ubuntu.com/noble/python3-pip
+
+Package: python3-venv
+License: PSF-2.0
+URL: https://packages.ubuntu.com/noble/python3-venv
+
+Package: traceroute
+License: GPL-2.0
+URL: https://packages.ubuntu.com/noble/traceroute
+
+Package: vim-tiny
+License: Vim
+URL: https://packages.ubuntu.com/noble/vim-tiny
+
+================================================================================
+NPM Packages
+================================================================================
+
+Package: openclaw
+License: Apache-2.0
+URL: https://www.npmjs.com/package/openclaw
+
+================================================================================
+GitHub Actions
+================================================================================
+
+Action: actions/checkout@v4
+License: MIT
+URL: https://github.com/actions/checkout
+
+Action: actions/setup-python@v5
+License: MIT
+URL: https://github.com/actions/setup-python
+
+Action: docker/setup-qemu-action@v3
+License: Apache-2.0
+URL: https://github.com/docker/setup-qemu-action
+
+Action: docker/setup-buildx-action@v3
+License: Apache-2.0
+URL: https://github.com/docker/setup-buildx-action
+
+Action: docker/login-action@v3
+License: Apache-2.0
+URL: https://github.com/docker/login-action
+
+Action: docker/metadata-action@v5
+License: Apache-2.0
+URL: https://github.com/docker/metadata-action
+
+Action: docker/build-push-action@v6
+License: Apache-2.0
+URL: https://github.com/docker/build-push-action
+
+Action: gsactions/dco-check@v1.1.1
+License: ISC
+URL: https://github.com/gsactions/dco-check
+
+================================================================================
+CI Runtime Images
+================================================================================
+
+Image: registry:2
+License: Apache-2.0
+URL: https://hub.docker.com/_/registry

--- a/scripts/check_license_headers.py
+++ b/scripts/check_license_headers.py
@@ -44,7 +44,6 @@ COMMENT_STYLES: dict[str, str] = {
 # Directories to skip entirely (relative to repo root).
 EXCLUDE_DIRS: set[str] = {
     ".git",
-    ".github",
     ".venv",
     "__pycache__",
 }


### PR DESCRIPTION
## Summary

Closes #1 — addresses the remaining open-source compliance gaps on `main`.

- **SPDX header**: Added missing header to `.github/workflows/dco.yml` (the only source file without one)
- **DCO in CONTRIBUTING.md**: Added "Developer Certificate of Origin" section with sign-off instructions and `git commit -s` example
- **THIRD-PARTY-NOTICES**: New file listing all third-party dependencies (Docker base images, APT packages, npm packages, GitHub Actions, CI images) with license identifiers and upstream URLs
- **CI scope fix**: Removed `.github/` from the license header check exclusion list so future workflow files are validated

### Issue #1 Acceptance Criteria

| Criteria | Status |
|---|---|
| `LICENSE` file present at repo root (Apache 2.0) | Already on main |
| All existing source files have SPDX copyright headers | Fixed (dco.yml was missing) |
| `CONTRIBUTING.md` present with DCO requirement | Fixed (DCO section added) |
| `THIRD-PARTY-NOTICES` file present with current dependency list | Added |
| (Optional) CI check blocks PRs missing headers | Already on main; scope expanded to include `.github/` |