### PR TITLE
chore: change base container image to nvcr.io/nvidia/base/ubuntu:noble-20251013

### DIFF
--- a/sandboxes/base/Dockerfile
+++ b/sandboxes/base/Dockerfile
@@ -11,7 +11,7 @@
 # Build:  docker build -t openshell-base .
 
 # System base
-FROM ubuntu:24.04 AS system
+FROM nvcr.io/nvidia/base/ubuntu:noble-20251013 AS system
 
 ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONDONTWRITEBYTECODE=1 \


### PR DESCRIPTION
## Summary

- Switches the base sandbox container image from `ubuntu:24.04` to `nvcr.io/nvidia/base/ubuntu:noble-20251013` to align with NVIDIA's NGC container ecosystem
- All downstream sandbox images (openclaw, nemoclaw) inherit from this base, so the change propagates through the entire image hierarchy

Closes #19