### PR TITLE
fix: add missing apt deps and address high-severity sandbox image vulnerabilities

### DIFF
--- a/sandboxes/base/Dockerfile
+++ b/sandboxes/base/Dockerfile
@@ -56,6 +56,11 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
         nano \
     && rm -rf /var/lib/apt/lists/*
 
+# Fix transitive tar vulnerabilities (GHSA-qffp-2rhf-9h96,
+# GHSA-9ppj-qmqm-q256, GHSA-8qq5-rm4j-mr97, GHSA-r6q2-hw4h-h46w,
+# GHSA-34x7-hfp2-rc4v, GHSA-83g3-92jg-28cx).
+RUN npm install -g tar@7.5.11
+
 # GitHub CLI
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
         -o /usr/share/keyrings/githubcli-archive-keyring.gpg && \

--- a/sandboxes/nemoclaw/Dockerfile
+++ b/sandboxes/nemoclaw/Dockerfile
@@ -27,6 +27,9 @@ COPY policy-proxy.js /usr/local/lib/policy-proxy.js
 COPY proto/ /usr/local/lib/nemoclaw-proto/
 RUN npm install -g @grpc/grpc-js @grpc/proto-loader js-yaml
 
+# Fix @hono/node-server authorization bypass (GHSA-wc8c-qw6v-h7f6)
+RUN npm install -g @hono/node-server@1.19.11
+
 # Allow the sandbox user to read the default policy (the startup script
 # copies it to a writable location; this chown covers non-Landlock envs)
 RUN chown -R sandbox:sandbox /etc/navigator

--- a/sandboxes/openclaw/Dockerfile
+++ b/sandboxes/openclaw/Dockerfile
@@ -14,8 +14,8 @@ FROM ${BASE_IMAGE}
 
 USER root
 
-# Install OpenClaw CLI
-RUN npm install -g openclaw
+# Install OpenClaw CLI (pinned to fix GHSA-rchv-x836-w7xp, GHSA-6mgf-v5j7-45cr)
+RUN npm install -g openclaw@2026.3.7
 
 # Copy sandbox policy
 COPY policy.yaml /etc/navigator/policy.yaml


### PR DESCRIPTION
## Summary

- Add `openssh-sftp-server` and `procps` to the base sandbox image (required for VS Code / Cursor remote SSH)
- Fix 9 high-severity vulnerabilities across the sandbox image chain
- Pin package versions for reproducibility and security

## Vulnerability Scan Disposition

| # | Advisory | Severity | Package | Installed | Fixed | Dockerfile | Action |
|---|----------|----------|---------|-----------|-------|------------|--------|
| 1 | [GHSA-6xvm-j4wr-6v98](https://github.com/advisories/GHSA-6xvm-j4wr-6v98) | High | `quinn-proto` | 0.11.12 | 0.11.14 | — | **No fix available.** Rust crate from upstream NVIDIA base image or openshell binary. Not controlled by community Dockerfiles. |
| 2 | [GHSA-wc8c-qw6v-h7f6](https://github.com/advisories/GHSA-wc8c-qw6v-h7f6) | High | `@hono/node-server` | 1.19.9 | 1.19.10 | `nemoclaw/Dockerfile` | **Fixed.** Force-upgraded to `@hono/node-server@1.19.11`. |
| 3 | [GHSA-rchv-x836-w7xp](https://github.com/advisories/GHSA-rchv-x836-w7xp) | High | `openclaw` | 2026.3.2 | 2026.3.7 | `openclaw/Dockerfile` | **Fixed.** Pinned to `openclaw@2026.3.7`. |
| 4 | [GHSA-6mgf-v5j7-45cr](https://github.com/advisories/GHSA-6mgf-v5j7-45cr) | High | `openclaw` | 2026.3.2 | 2026.3.7 | `openclaw/Dockerfile` | **Fixed.** Same pin as #3. |
| 5 | [GHSA-qffp-2rhf-9h96](https://github.com/advisories/GHSA-qffp-2rhf-9h96) | High | `tar` | 7.5.9 | 7.5.10 | `base/Dockerfile` | **Fixed.** Force-upgraded to `tar@7.5.11`. |
| 6 | [GHSA-9ppj-qmqm-q256](https://github.com/advisories/GHSA-9ppj-qmqm-q256) | High | `tar` | 7.5.9 | 7.5.11 | `base/Dockerfile` | **Fixed.** Same as #5. |
| 7 | [GHSA-8qq5-rm4j-mr97](https://github.com/advisories/GHSA-8qq5-rm4j-mr97) | High | `tar` | 6.2.1 | 7.5.3 | `base/Dockerfile` | **Fixed.** Same as #5 — `tar@7.5.11` supersedes all prior fix versions. |
| 8 | [GHSA-r6q2-hw4h-h46w](https://github.com/advisories/GHSA-r6q2-hw4h-h46w) | High | `tar` | 6.2.1 | 7.5.4 | `base/Dockerfile` | **Fixed.** Same as #5. |
| 9 | [GHSA-34x7-hfp2-rc4v](https://github.com/advisories/GHSA-34x7-hfp2-rc4v) | High | `tar` | 6.2.1 | 7.5.7 | `base/Dockerfile` | **Fixed.** Same as #5. |
| 10 | [GHSA-83g3-92jg-28cx](https://github.com/advisories/GHSA-83g3-92jg-28cx) | High | `tar` | 6.2.1 | 7.5.8 | `base/Dockerfile` | **Fixed.** Same as #5. |
| 11 | [CVE-2024-52308](https://ubuntu.com/security/CVE-2024-52308) | High | `gh` | 2.87.3 | None | `base/Dockerfile` | **False positive.** Fix landed in gh 2.62.0; installed version 2.87.3 already contains the patch. |

### Not addressable in this repo

| Package | Reason |
|---------|--------|
| `quinn-proto` | Rust crate baked into upstream binary/base image. Requires fix in openshell (non-community) or the NVIDIA base image. |
| `gh` | Scanner metadata issue — installed version already patched. |

## Changes

### `sandboxes/base/Dockerfile`
- Add `openssh-sftp-server` and `procps` apt packages
- Add `npm install -g tar@7.5.11` after Node.js install (fixes 6 tar CVEs)

### `sandboxes/openclaw/Dockerfile`
- Pin `openclaw@2026.3.7` (fixes 2 openclaw CVEs: auth material leak + cross-origin header forwarding)

### `sandboxes/nemoclaw/Dockerfile`
- Add `npm install -g @hono/node-server@1.19.11` (fixes authorization bypass via encoded slashes)