### PR TITLE
fix: restore cluster_pods network policy for nemoclaw and openclaw

### DIFF
--- a/sandboxes/nemoclaw/policy.yaml
+++ b/sandboxes/nemoclaw/policy.yaml
@@ -127,3 +127,16 @@ network_policies:
       - { path: /usr/local/bin/claude }
       - { path: /usr/bin/gh }
 
+  # --- Private network access (allowed_ips) ---
+  # Allows any binary to reach services on the k3s cluster pod network
+  # (10.42.0.0/16). Without allowed_ips, the proxy's SSRF check blocks
+  # all connections to private RFC 1918 addresses.
+  cluster_pods:
+    name: cluster-pods
+    endpoints:
+      - port: 8080
+        allowed_ips:
+          - "10.42.0.0/16"
+    binaries:
+      - { path: "/**" }
+

--- a/sandboxes/openclaw/policy.yaml
+++ b/sandboxes/openclaw/policy.yaml
@@ -126,7 +126,18 @@ network_policies:
       - { path: /usr/local/bin/claude }
       - { path: /usr/bin/gh }
 
-
+  # --- Private network access (allowed_ips) ---
+  # Allows any binary to reach services on the k3s cluster pod network
+  # (10.42.0.0/16). Without allowed_ips, the proxy's SSRF check blocks
+  # all connections to private RFC 1918 addresses.
+  cluster_pods:
+    name: cluster-pods
+    endpoints:
+      - port: 8080
+        allowed_ips:
+          - "10.42.0.0/16"
+    binaries:
+      - { path: "/**" }
 
 inference:
   allowed_routes:


### PR DESCRIPTION
## Summary

- Restore the `cluster_pods` allowed_ips network policy that was accidentally removed from nemoclaw and openclaw in #24.
- This policy allows sandbox binaries to reach services on the k3s cluster pod network (`10.42.0.0/16` on port 8080), which is required for internal service communication.