### PR TITLE
fix: rename /etc/navigator policy paths to /etc/openshell

### DIFF
--- a/sandboxes/base/Dockerfile
+++ b/sandboxes/base/Dockerfile
@@ -107,7 +107,7 @@ ENV PATH="/sandbox/.venv/bin:/usr/local/bin:/usr/bin:/bin" \
     VIRTUAL_ENV="/sandbox/.venv"
 
 # Default sandbox network / filesystem policy
-COPY policy.yaml /etc/navigator/policy.yaml
+COPY policy.yaml /etc/openshell/policy.yaml
 
 # Copy custom skills into the image.
 # To add a skill, create a subdirectory under sandboxes/base/skills/

--- a/sandboxes/nemoclaw/Dockerfile
+++ b/sandboxes/nemoclaw/Dockerfile
@@ -32,7 +32,7 @@ RUN npm install -g @hono/node-server@1.19.11
 
 # Allow the sandbox user to read the default policy (the startup script
 # copies it to a writable location; this chown covers non-Landlock envs)
-RUN chown -R sandbox:sandbox /etc/navigator
+RUN chown -R sandbox:sandbox /etc/openshell
 
 # Stage the NeMoClaw DevX extension source
 COPY nemoclaw-ui-extension/extension/ /opt/nemoclaw-devx/

--- a/sandboxes/nemoclaw/nemoclaw-start.sh
+++ b/sandboxes/nemoclaw/nemoclaw-start.sh
@@ -116,7 +116,7 @@ nohup openclaw gateway > /tmp/gateway.log 2>&1 &
 # update it at runtime.  /etc is read-only under Landlock, but /sandbox is
 # read-write, so we use /sandbox/.openclaw/ which is already owned by the
 # sandbox user.
-_POLICY_SRC="/etc/navigator/policy.yaml"
+_POLICY_SRC="/etc/openshell/policy.yaml"
 _POLICY_DST="/sandbox/.openclaw/policy.yaml"
 if [ ! -f "$_POLICY_DST" ] && [ -f "$_POLICY_SRC" ]; then
   cp "$_POLICY_SRC" "$_POLICY_DST" 2>/dev/null || true

--- a/sandboxes/nemoclaw/policy-proxy.js
+++ b/sandboxes/nemoclaw/policy-proxy.js
@@ -15,7 +15,7 @@ const fs = require("fs");
 const os = require("os");
 const net = require("net");
 
-const POLICY_PATH = process.env.POLICY_PATH || "/etc/navigator/policy.yaml";
+const POLICY_PATH = process.env.POLICY_PATH || "/etc/openshell/policy.yaml";
 const UPSTREAM_PORT = parseInt(process.env.UPSTREAM_PORT || "18788", 10);
 const LISTEN_PORT = parseInt(process.env.LISTEN_PORT || "18789", 10);
 const UPSTREAM_HOST = "127.0.0.1";
@@ -26,9 +26,9 @@ const PROTO_DIR = "/usr/local/lib/nemoclaw-proto";
 // platform).  When the proxy runs inside an SSH session the env vars are
 // cleared, but the files on disk remain accessible.
 const TLS_WELL_KNOWN = {
-  ca:   "/etc/navigator-tls/client/ca.crt",
-  cert: "/etc/navigator-tls/client/tls.crt",
-  key:  "/etc/navigator-tls/client/tls.key",
+  ca:   "/etc/openshell-tls/client/ca.crt",
+  cert: "/etc/openshell-tls/client/tls.crt",
+  key:  "/etc/openshell-tls/client/tls.key",
 };
 
 const WELL_KNOWN_ENDPOINT = "https://navigator.navigator.svc.cluster.local:8080";

--- a/sandboxes/openclaw/Dockerfile
+++ b/sandboxes/openclaw/Dockerfile
@@ -19,7 +19,7 @@ USER root
 RUN npm install -g openclaw@2026.3.11
 
 # Copy sandbox policy
-COPY policy.yaml /etc/navigator/policy.yaml
+COPY policy.yaml /etc/openshell/policy.yaml
 
 # Copy the OpenClaw startup helper
 COPY openclaw-start.sh /usr/local/bin/openclaw-start


### PR DESCRIPTION
## Summary

- Renames all sandbox policy paths from `/etc/navigator/` to `/etc/openshell/` to complete the OpenShell rebrand
- Renames TLS credential paths from `/etc/navigator-tls/` to `/etc/openshell-tls/`

## Changed files

| File | Change |
|------|--------|
| `sandboxes/base/Dockerfile` | `COPY policy.yaml /etc/navigator/...` → `/etc/openshell/...` |
| `sandboxes/openclaw/Dockerfile` | `COPY policy.yaml /etc/navigator/...` → `/etc/openshell/...` |
| `sandboxes/nemoclaw/Dockerfile` | `chown /etc/navigator` → `/etc/openshell` |
| `sandboxes/nemoclaw/policy-proxy.js` | Default policy path + TLS well-known paths |
| `sandboxes/nemoclaw/nemoclaw-start.sh` | `_POLICY_SRC` path |