### PR TITLE
chore(sandbox): add iptables to base image for bypass diagnostics

### DIFF
--- a/sandboxes/base/Dockerfile
+++ b/sandboxes/base/Dockerfile
@@ -21,6 +21,7 @@ WORKDIR /sandbox
 
 # Core system dependencies
 # iproute2: network namespace management (ip netns, veth pairs)
+# iptables: bypass detection — LOG + REJECT rules for direct connection diagnostics
 # dnsutils: dig, nslookup
 # Python is managed entirely by uv (see devtools stage).
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -28,6 +29,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
         dnsutils \
         iproute2 \
+        iptables \
         iputils-ping \
         net-tools \
         netcat-openbsd \


### PR DESCRIPTION
## Summary
Add `iptables` package to the base sandbox image. The OpenShell sandbox supervisor will use this to install LOG + REJECT rules in the network namespace for proxy bypass detection.

## Related Issue
Ref: NVIDIA/OpenShell#268

## Changes
- `sandboxes/base/Dockerfile`: Add `iptables` to the core system dependencies `apt-get install` line

## Context
When a sandbox process attempts a direct outbound connection that bypasses the HTTP CONNECT proxy (e.g., Node.js `fetch()` without `NODE_USE_ENV_PROXY=1`), the connection currently hangs silently for 30+ seconds. With `iptables` available, the supervisor can:

1. **REJECT** bypass attempts immediately (ECONNREFUSED instead of timeout)
2. **LOG** diagnostic events with destination, protocol, and process identity

The supervisor already has `CAP_NET_ADMIN` and runs as root — this is purely a package availability change. If `iptables` is not present, the feature degrades gracefully (warning logged, namespace still isolates via routing).

Same pattern as `iproute2` which is already a required dependency.

## Checklist
- [x] Follows Conventional Commits
- [x] No capability or security context changes required
- [x] Existing sandbox behavior unchanged — iptables rules are only installed by the supervisor (not yet shipped)