### PR TITLE
feat: add Kode-Agent to base sandbox image

### DIFF
--- a/sandboxes/base/Dockerfile
+++ b/sandboxes/base/Dockerfile
@@ -74,7 +74,8 @@ RUN npm install -g \
         tar@7.5.11 \
         @hono/node-server@1.19.11 \
         opencode-ai@1.2.18 \
-        @openai/codex@0.111.0
+        @openai/codex@0.111.0 \
+        @shareai-lab/kode@2.2.0
 
 # GitHub CLI
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \

--- a/sandboxes/base/policy.yaml
+++ b/sandboxes/base/policy.yaml
@@ -93,6 +93,7 @@ network_policies:
         access: read-only
     binaries:
       - { path: /usr/local/bin/claude }
+      - { path: /usr/local/bin/kode }
       - { path: /usr/bin/gh }
 
   pypi:
@@ -159,3 +160,12 @@ network_policies:
     - path: /usr/lib/node_modules/opencode-ai/bin/.opencode
     - path: /usr/bin/node
     - path: /usr/local/bin/opencode
+
+  kode_agent:
+    name: kode-agent
+    endpoints:
+      - { host: api.anthropic.com, port: 443, protocol: rest, enforcement: enforce, access: full, tls: terminate }
+      - { host: api.openai.com, port: 443 }
+    binaries:
+      - { path: /usr/local/bin/kode }
+      - { path: /usr/bin/node }


### PR DESCRIPTION
## Summary

Add [Kode](https://github.com/shareAI-lab/Kode-Agent) (`@shareai-lab/kode@2.2.0`) to the base sandbox image alongside Claude Code, OpenCode, and Codex.

## Related Issue

N/A — new agent integration. Companion PR: [NVIDIA/OpenShell#391](https://github.com/NVIDIA/OpenShell/pull/391)

## Changes

- **`sandboxes/base/Dockerfile`**: Install `@shareai-lab/kode@2.2.0` via npm alongside existing agent CLIs
- **`sandboxes/base/policy.yaml`**: Add `kode_agent` network policy allowing `/usr/local/bin/kode` and `/usr/bin/node` to reach `api.anthropic.com` and `api.openai.com`; grant kode binary access to GitHub REST API

## Testing

- [ ] Docker image builds successfully with kode installed
- [ ] `kode --version` works inside the sandbox
- [ ] Network policy allows kode to reach api.anthropic.com and api.openai.com

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed off (DCO)