### PR TITLE
fix: add /usr/bin/node to nvidia network policy

### DIFF
--- a/sandboxes/openclaw/policy.yaml
+++ b/sandboxes/openclaw/policy.yaml
@@ -85,6 +85,7 @@ network_policies:
       - { path: /usr/bin/curl }
       - { path: /bin/bash }
       - { path: /usr/local/bin/opencode }
+      - { path: /usr/bin/node }
   nvidia_web:
     name: nvidia_web
     endpoints:


### PR DESCRIPTION
In the sandbox manual install, /usr/bin/node is missing under
   the nvidia network policy and blocking requests to integrate.api.nvidia.com