### PR TITLE
feat: add GitHub Copilot support

### DIFF
--- a/sandboxes/base/Dockerfile
+++ b/sandboxes/base/Dockerfile
@@ -74,7 +74,8 @@ RUN npm install -g \
         tar@7.5.11 \
         @hono/node-server@1.19.11 \
         opencode-ai@1.2.18 \
-        @openai/codex@0.111.0
+        @openai/codex@0.111.0 \
+        @github/copilot@1.0.9
 
 # GitHub CLI
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \

--- a/sandboxes/base/README.md
+++ b/sandboxes/base/README.md
@@ -9,7 +9,7 @@ The foundational sandbox image that all other OpenShell Community sandbox images
 | OS | Ubuntu 24.04 |
 | Languages | `python3` (3.13), `node` (22.22.1) |
 | Package managers | `npm` (11.11.0), `uv` (0.10.8), `pip` |
-| Coding agents | `claude`, `opencode`, `codex` |
+| Coding agents | `claude`, `opencode`, `codex`, `copilot` |
 | Developer | `gh`, `git`, `vim`, `nano` |
 | Networking | `ping`, `dig`, `nslookup`, `nc`, `traceroute`, `netstat`, `curl` |
 

--- a/sandboxes/base/policy.yaml
+++ b/sandboxes/base/policy.yaml
@@ -159,3 +159,16 @@ network_policies:
     - path: /usr/lib/node_modules/opencode-ai/bin/.opencode
     - path: /usr/bin/node
     - path: /usr/local/bin/opencode
+
+  copilot:
+    name: copilot
+    endpoints:
+    - { host: github.com, port: 443 }
+    - { host: api.github.com, port: 443 }
+    - { host: api.githubcopilot.com, port: 443 }
+    - { host: api.enterprise.githubcopilot.com, port: 443 }
+    - { host: release-assets.githubusercontent.com, port: 443 }
+    - { host: copilot-proxy.githubusercontent.com, port: 443 }
+    - { host: default.exp-tas.com, port: 443 }
+    binaries:
+    - { path: /usr/lib/node_modules/@github/copilot/node_modules/@github/**/copilot }


### PR DESCRIPTION
adds copilot as a global tool during the npm install phase
adds copilot endpoints to the base policy file