### PR TITLE
feat(sandbox/ollama): allow updating ollama from within the sandbox

### DIFF
--- a/sandboxes/ollama/Dockerfile
+++ b/sandboxes/ollama/Dockerfile
@@ -17,20 +17,26 @@ USER root
 RUN apt-get update && apt-get install -y --no-install-recommends zstd \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Ollama
-RUN curl -fsSL https://ollama.com/install.sh | sh
+# Install Ollama into /sandbox/bin so it lives on a writable path and can be
+# updated at runtime (the sandbox policy makes /usr read-only).
+RUN mkdir -p /sandbox/bin && \
+    curl -fsSL https://ollama.com/install.sh | sh && \
+    mv /usr/local/bin/ollama /sandbox/bin/ollama && \
+    chown -R sandbox:sandbox /sandbox/bin
 
 # Copy sandbox policy
 COPY policy.yaml /etc/openshell/policy.yaml
 
-# Copy entrypoint script
+# Copy entrypoint and update scripts
 COPY entrypoint.sh /usr/local/bin/entrypoint
-RUN chmod +x /usr/local/bin/entrypoint
+COPY update-ollama.sh /sandbox/bin/update-ollama
+RUN chmod +x /usr/local/bin/entrypoint /sandbox/bin/update-ollama
 
 # Set environment variables for OpenShell provider discovery
+# /sandbox/bin comes first so the writable ollama binary is preferred
 ENV OLLAMA_HOST=http://127.0.0.1:11434 \
     NPM_CONFIG_PREFIX=/sandbox/.npm-global \
-    PATH="/sandbox/.npm-global/bin:/sandbox/.venv/bin:/usr/local/bin:/usr/bin:/bin"
+    PATH="/sandbox/bin:/sandbox/.npm-global/bin:/sandbox/.venv/bin:/usr/local/bin:/usr/bin:/bin"
 
 # Configure npm to install globals into a writable directory
 # (the sandbox policy makes /usr read-only, so the default /usr/lib/node_modules fails)
@@ -40,7 +46,7 @@ RUN mkdir -p /sandbox/.npm-global && \
 # Add environment variables to .bashrc for interactive shells
 RUN echo 'export OLLAMA_HOST=http://127.0.0.1:11434' >> /sandbox/.bashrc && \
     echo 'export NPM_CONFIG_PREFIX=/sandbox/.npm-global' >> /sandbox/.bashrc && \
-    echo 'export PATH="/sandbox/.npm-global/bin:$PATH"' >> /sandbox/.bashrc && \
+    echo 'export PATH="/sandbox/bin:/sandbox/.npm-global/bin:$PATH"' >> /sandbox/.bashrc && \
     chown sandbox:sandbox /sandbox/.bashrc
 
 USER sandbox

--- a/sandboxes/ollama/README.md
+++ b/sandboxes/ollama/README.md
@@ -26,3 +26,15 @@ docker build -t openshell-ollama .
 openshell sandbox create --from ollama
 ```
 
+### Update Ollama inside the sandbox
+
+```bash
+update-ollama
+```
+
+Or auto-update on startup:
+
+```bash
+openshell sandbox create --from ollama -e OLLAMA_UPDATE=1
+```
+

--- a/sandboxes/ollama/entrypoint.sh
+++ b/sandboxes/ollama/entrypoint.sh
@@ -9,6 +9,12 @@ set -euo pipefail
 # Export OLLAMA_HOST for OpenShell provider discovery
 export OLLAMA_HOST="${OLLAMA_HOST:-http://127.0.0.1:11434}"
 
+# Update Ollama if requested
+if [ "${OLLAMA_UPDATE:-0}" = "1" ]; then
+    echo "[ollama] Updating to latest version..."
+    update-ollama
+fi
+
 # Start Ollama server in background
 echo "[ollama] Starting Ollama server..."
 nohup ollama serve > /tmp/ollama.log 2>&1 &

--- a/sandboxes/ollama/policy.yaml
+++ b/sandboxes/ollama/policy.yaml
@@ -45,10 +45,12 @@ network_policies:
       - { host: github.com, port: 443 }
       - { host: objects.githubusercontent.com, port: 443 }
       - { host: raw.githubusercontent.com, port: 443 }
+      - { host: release-assets.githubusercontent.com, port: 443 }
     binaries:
       - { path: /usr/bin/curl }
       - { path: /bin/bash }
       - { path: /usr/bin/sh }
+      - { path: /sandbox/bin/ollama }
       - { path: /usr/local/bin/ollama }
       - { path: /usr/bin/ollama }
 

--- a/sandboxes/ollama/update-ollama.sh
+++ b/sandboxes/ollama/update-ollama.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# SPDX-License-Identifier: Apache-2.0
+
+# Update Ollama inside the sandbox.
+# Usage: update-ollama [VERSION]
+#   update-ollama          # install latest
+#   update-ollama 0.18.1   # install specific version
+set -euo pipefail
+
+OLLAMA_BIN="/sandbox/bin/ollama"
+VERSION="${1:-}"
+
+ARCH=$(uname -m)
+case "$ARCH" in
+    x86_64)  ARCH="amd64" ;;
+    aarch64) ARCH="arm64" ;;
+    arm64)   ARCH="arm64" ;;
+    *)       echo "Unsupported architecture: $ARCH"; exit 1 ;;
+esac
+
+CURRENT=$("$OLLAMA_BIN" --version 2>&1 | grep -oP 'version is \K[0-9.]+' || echo "unknown")
+
+if [ -n "$VERSION" ]; then
+    URL="https://github.com/ollama/ollama/releases/download/v${VERSION}/ollama-linux-${ARCH}.tar.zst"
+    echo "Current version: ${CURRENT}"
+    echo "Downloading ollama v${VERSION} for linux/${ARCH}..."
+else
+    URL="https://ollama.com/download/ollama-linux-${ARCH}.tar.zst"
+    echo "Current version: ${CURRENT}"
+    echo "Downloading latest ollama for linux/${ARCH}..."
+fi
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+curl -fsSL "$URL" -o "$TMPDIR/ollama.tar.zst"
+tar --zstd -xf "$TMPDIR/ollama.tar.zst" -C "$TMPDIR"
+
+mv "$TMPDIR/bin/ollama" "$OLLAMA_BIN"
+chmod +x "$OLLAMA_BIN"
+
+NEW=$("$OLLAMA_BIN" --version 2>&1 | grep -oP 'version is \K[0-9.]+' || echo "unknown")
+
+echo "Updated: ${CURRENT} -> ${NEW}"
+echo "Restart the Ollama server to use the new version:"
+echo "  pkill ollama; nohup ollama serve > /tmp/ollama.log 2>&1 &"


### PR DESCRIPTION
Move ollama binary to /sandbox/bin/ (writable at runtime) so it can be replaced without rebuilding the container image.
Added an update-ollama script that downloads a specific version or latest, and support OLLAMA_UPDATE=1 env var for auto-update on startup.