### PR TITLE
update Dockerfile of base sandbox to last version of OpenCode

### DIFF
--- a/sandboxes/base/Dockerfile
+++ b/sandboxes/base/Dockerfile
@@ -73,7 +73,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
 RUN npm install -g \
         tar@7.5.11 \
         @hono/node-server@1.19.11 \
-        opencode-ai@1.2.18 \
+        opencode-ai@1.3.2 \
         @openai/codex@0.111.0 \
         @github/copilot@1.0.9
 


### PR DESCRIPTION
Hi,
As per title: last stable version of OpenCode is now 1.3.2.
Updating base Dockerfile to this version
Didier