### PR TITLE
improve codex coverage in base sandbox

### DIFF
--- a/sandboxes/base/Dockerfile
+++ b/sandboxes/base/Dockerfile
@@ -74,7 +74,7 @@ RUN npm install -g \
         tar@7.5.11 \
         @hono/node-server@1.19.11 \
         opencode-ai@1.2.18 \
-        @openai/codex@0.111.0 \
+        @openai/codex@0.117.0 \
         @github/copilot@1.0.9
 
 # GitHub CLI

--- a/sandboxes/base/README.md
+++ b/sandboxes/base/README.md
@@ -56,3 +56,13 @@ FROM ${BASE_IMAGE}
 ```
 
 See `sandboxes/openclaw/` for an example.
+
+## Codex authentication
+
+For remote or headless OpenShell environments, if browser login hangs, try authenticating Codex with:
+
+```bash
+codex login --device-auth
+```
+
+If device-code login is unreliable in your environment, you can authenticate on another machine and copy ~/.codex/auth.json into the sandbox.

--- a/sandboxes/base/policy.yaml
+++ b/sandboxes/base/policy.yaml
@@ -172,3 +172,14 @@ network_policies:
     - { host: default.exp-tas.com, port: 443 }
     binaries:
     - { path: /usr/lib/node_modules/@github/copilot/node_modules/@github/**/copilot }
+
+  codex:
+    name: codex
+    endpoints:
+      - { host: api.openai.com,  port: 443 }
+      - { host: auth.openai.com, port: 443 }
+      - { host: chatgpt.com,     port: 443 }
+    binaries:
+      - { path: /usr/bin/codex }
+      - { path: /usr/bin/node }
+      - { path: "/usr/lib/node_modules/@openai/**" }


### PR DESCRIPTION
## Summary

Make the `base` sandbox Codex-ready by:

- adding a `codex` network policy to `sandboxes/base/policy.yaml`
- updating the bundled Codex CLI from `@openai/codex@0.111.0` to `@openai/codex@0.117.0`
- documenting recommended authentication guidance for remote/headless OpenShell environments in `sandboxes/base/README.md`

## Motivation

The current `base` sandbox includes Codex as an installed coding agent, but in practice it does not work out of the box because:

- `base/policy.yaml` does not currently include a `codex` policy block
- the bundled Codex version (`0.111.0`) is outdated
- subscription-backed Codex usage requires access to additional hosts beyond `api.openai.com`

This PR is intended to make the `base` template better match user expectations for a stock Codex-enabled sandbox.

## Changes

### 1) Update bundled Codex version

In `sandboxes/base/Dockerfile`:

- bump `@openai/codex` from `0.111.0` to `0.117.0`

### 2) Add Codex policy coverage

In `sandboxes/base/policy.yaml`:

- add a new `codex` network policy
- allow outbound access to:
  - `api.openai.com:443`
  - `auth.openai.com:443`
  - `chatgpt.com:443`
- match the stock bundled Codex install paths:
  - `/usr/bin/codex`
  - `/usr/bin/node`
  - `/usr/lib/node_modules/@openai/**`

### 3) Add authentication note to README

In `sandboxes/base/README.md`:

- add a short note recommending `codex login --device-auth` for remote/headless OpenShell environments

## Why these hosts are needed

During testing, the following were required for Codex to function correctly in `base`:

- `auth.openai.com` for device-code authentication
- `chatgpt.com` for ChatGPT-sign-in-backed Codex traffic
- `api.openai.com` for Codex/OpenAI API traffic

## Testing

Tested by creating a fresh sandbox from the modified local `sandboxes/base` directory and verifying:

- bundled Codex resolved to the stock system install path
- `codex --version` reported `0.117.0`
- `auth.openai.com` was reachable from inside the sandbox
- the device auth endpoint returned a valid device code from inside the sandbox
- Codex traffic to the required hosts was allowed by OpenShell policy
- Codex was able to work in the sandbox after authentication

## Notes

- `codex login --device-auth` appears to be the most practical authentication path for remote/headless OpenShell environments.
- In testing, device-auth itself could still be somewhat flaky at the CLI layer even when the underlying auth endpoint and policy were working correctly.
- Because of that, the README note is intended as practical guidance, not as a guarantee that device-auth is universally flawless in every environment.
- If maintainers prefer, I can also update the README wording to mention that `~/.codex/auth.json` copy-in is a fallback for environments where interactive login is unreliable.

## Scope

This PR is intentionally limited to the `base` sandbox template and related documentation. It does not attempt to change broader OpenShell core auth/provider behavior.