### PR TITLE
update Openclaw Dockerfile to last version

### DIFF
--- a/sandboxes/openclaw/Dockerfile
+++ b/sandboxes/openclaw/Dockerfile
@@ -16,7 +16,7 @@ USER root
 
 # Install OpenClaw CLI (pinned to fix GHSA-rchv-x836-w7xp, GHSA-6mgf-v5j7-45cr,
 # GHSA-5wcw-8jjv-m286)
-RUN npm install -g openclaw@2026.3.11
+RUN npm install -g openclaw@2026.3.24
 
 # Copy sandbox policy
 COPY policy.yaml /etc/openshell/policy.yaml


### PR DESCRIPTION
Hi,

OpenClaw is now at version 2026.3.24. while this repo is still at 2026.3.11

Lots of fixes (incl security issues) have been included in intermediate versions since 2026.3.11. 
See https://github.com/openclaw/openclaw/releases.

So, the OpenClaw Dockerfile of NemoClaw should also be updated.

Didier