### PR TITLE
Update Node.js installation to latest version in base sandbox

### DIFF
--- a/sandboxes/base/Dockerfile
+++ b/sandboxes/base/Dockerfile
@@ -74,7 +74,7 @@ RUN npm install -g \
         tar@7.5.11 \
         @hono/node-server@1.19.11 \
         opencode-ai@1.2.18 \
-        @openai/codex@0.111.0 \
+        @openai/codex@0.117.0 \
         @github/copilot@1.0.9
 
 # GitHub CLI

--- a/sandboxes/base/Dockerfile
+++ b/sandboxes/base/Dockerfile
@@ -58,7 +58,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
     apt-get install -y --no-install-recommends \
         build-essential \
         git \
-        nodejs=22.22.1-1nodesource1 \
+        nodejs \
         vim-tiny \
         nano \
     && rm -rf /var/lib/apt/lists/* \

--- a/sandboxes/base/README.md
+++ b/sandboxes/base/README.md
@@ -56,3 +56,13 @@ FROM ${BASE_IMAGE}
 ```
 
 See `sandboxes/openclaw/` for an example.
+
+## Codex authentication
+
+For remote or headless OpenShell environments, if browser login hangs, try authenticating Codex with:
+
+```bash
+codex login --device-auth
+```
+
+If device-code login is unreliable in your environment, you can authenticate on another machine and copy ~/.codex/auth.json into the sandbox.

--- a/sandboxes/base/policy.yaml
+++ b/sandboxes/base/policy.yaml
@@ -172,3 +172,14 @@ network_policies:
     - { host: default.exp-tas.com, port: 443 }
     binaries:
     - { path: /usr/lib/node_modules/@github/copilot/node_modules/@github/**/copilot }
+
+  codex:
+    name: codex
+    endpoints:
+      - { host: api.openai.com,  port: 443 }
+      - { host: auth.openai.com, port: 443 }
+      - { host: chatgpt.com,     port: 443 }
+    binaries:
+      - { path: /usr/bin/codex }
+      - { path: /usr/bin/node }
+      - { path: "/usr/lib/node_modules/@openai/**" }

--- a/sandboxes/test/Dockerfile
+++ b/sandboxes/test/Dockerfile
@@ -71,6 +71,8 @@ RUN echo 'export OLLAMA_HOST=http://127.0.0.1:11434' >> /sandbox/.bashrc && \
     echo 'export PATH="/opt/conda/bin:$PATH"' >> /sandbox/.bashrc && \
     chown sandbox:sandbox /sandbox/.bashrc
 
+ENV GIT_SSL_CAINFO=/etc/openshell-tls/ca-bundle.pem 
+
 USER sandbox
 
 ENTRYPOINT ["/usr/local/bin/entrypoint"]

--- a/sandboxes/test/Dockerfile
+++ b/sandboxes/test/Dockerfile
@@ -24,8 +24,8 @@ RUN apt-get update && apt-get install -y wget && \
 # Accept Anaconda ToS and install default conda packages
 RUN /opt/conda/bin/conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main \
     && /opt/conda/bin/conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r \
-    && /opt/conda/bin/conda install -y -c conda-forge \
-    vim htop nvtop ncurses numpy matplotlib \
+    && /opt/conda/bin/conda install -y -c conda-forge -c nvidia \
+    vim htop nvtop ncurses numpy matplotlib cuda-toolkit \
     && /opt/conda/bin/conda clean -afy
 
 # Make conda accessible to the sandbox user

--- a/sandboxes/test/Dockerfile
+++ b/sandboxes/test/Dockerfile
@@ -69,6 +69,7 @@ RUN echo 'export OLLAMA_HOST=http://127.0.0.1:11434' >> /sandbox/.bashrc && \
     echo 'export NPM_CONFIG_PREFIX=/sandbox/.npm-global' >> /sandbox/.bashrc && \
     echo 'export PATH="/sandbox/bin:/sandbox/.npm-global/bin:$PATH"' >> /sandbox/.bashrc && \
     echo 'export PATH="/opt/conda/bin:$PATH"' >> /sandbox/.bashrc && \
+    echo 'export GIT_SSL_CAINFO=/etc/openshell-tls/ca-bundle.pem' >> /sandbox/.bashrc && \
     chown sandbox:sandbox /sandbox/.bashrc
 
 ENV GIT_SSL_CAINFO=/etc/openshell-tls/ca-bundle.pem 

--- a/sandboxes/test/Dockerfile
+++ b/sandboxes/test/Dockerfile
@@ -21,6 +21,13 @@ RUN apt-get update && apt-get install -y wget && \
     rm /tmp/miniconda.sh && \
     /opt/conda/bin/conda clean -afy
 
+# Accept Anaconda ToS and install default conda packages
+RUN /opt/conda/bin/conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main \
+    && /opt/conda/bin/conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r \
+    && /opt/conda/bin/conda install -y -c conda-forge \
+    vim htop nvtop ncurses numpy matplotlib \
+    && /opt/conda/bin/conda clean -afy
+
 # Make conda accessible to the sandbox user
 RUN chown -R sandbox:sandbox /opt/conda
 

--- a/sandboxes/test/Dockerfile
+++ b/sandboxes/test/Dockerfile
@@ -1,0 +1,70 @@
+# syntax=docker/dockerfile:1.4
+
+# SPDX-License-Identifier: Apache-2.0
+
+# Ollama sandbox image for OpenShell
+#
+# Builds on the community base sandbox (has Node.js, Claude, Codex pre-installed).
+# Build:  docker build -t openshell-ollama --build-arg BASE_IMAGE=openshell-base .
+# Run:    openshell sandbox create --from ollama --forward 11434
+
+ARG BASE_IMAGE=ghcr.io/nvidia/openshell-community/sandboxes/base:latest
+FROM ${BASE_IMAGE}
+
+USER root
+
+
+# Install Miniconda as root during build
+RUN apt-get update && apt-get install -y wget && \
+    wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /tmp/miniconda.sh && \
+    bash /tmp/miniconda.sh -b -p /opt/conda && \
+    rm /tmp/miniconda.sh && \
+    /opt/conda/bin/conda clean -afy
+
+# Make conda accessible to the sandbox user
+RUN chown -R sandbox:sandbox /opt/conda
+
+# Add conda to PATH for the sandbox user
+ENV PATH="/opt/conda/bin:$PATH"
+
+# Install zstd (required by Ollama install script)
+RUN apt-get update && apt-get install -y --no-install-recommends zstd \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Ollama into /sandbox/bin so it lives on a writable path and can be
+# updated at runtime (the sandbox policy makes /usr read-only).
+RUN mkdir -p /sandbox/bin && \
+    curl -fsSL https://ollama.com/install.sh | sh && \
+    mv /usr/local/bin/ollama /sandbox/bin/ollama && \
+    chown -R sandbox:sandbox /sandbox/bin
+
+# Copy sandbox policy
+COPY policy.yaml /etc/openshell/policy.yaml
+
+# Copy entrypoint and update scripts
+COPY entrypoint.sh /usr/local/bin/entrypoint
+COPY update-ollama.sh /sandbox/bin/update-ollama
+RUN chmod +x /usr/local/bin/entrypoint /sandbox/bin/update-ollama
+
+# Set environment variables for OpenShell provider discovery
+# /sandbox/bin comes first so the writable ollama binary is preferred
+ENV OLLAMA_HOST=http://127.0.0.1:11434 \
+    NPM_CONFIG_PREFIX=/sandbox/.npm-global \
+    PATH="/sandbox/bin:/sandbox/.npm-global/bin:/sandbox/.venv/bin:/usr/local/bin:/usr/bin:/bin"
+
+# Configure npm to install globals into a writable directory
+# (the sandbox policy makes /usr read-only, so the default /usr/lib/node_modules fails)
+RUN mkdir -p /sandbox/.npm-global && \
+    chown sandbox:sandbox /sandbox/.npm-global
+
+# Add environment variables to .bashrc for interactive shells
+RUN echo 'export OLLAMA_HOST=http://127.0.0.1:11434' >> /sandbox/.bashrc && \
+    echo 'export NPM_CONFIG_PREFIX=/sandbox/.npm-global' >> /sandbox/.bashrc && \
+    echo 'export PATH="/sandbox/bin:/sandbox/.npm-global/bin:$PATH"' >> /sandbox/.bashrc && \
+    echo 'export PATH="/opt/conda/bin:$PATH"' >> /sandbox/.bashrc && \
+    chown sandbox:sandbox /sandbox/.bashrc
+
+USER sandbox
+
+ENTRYPOINT ["/usr/local/bin/entrypoint"]
+CMD ["/bin/bash", "-l"]

--- a/sandboxes/test/Dockerfile
+++ b/sandboxes/test/Dockerfile
@@ -57,6 +57,8 @@ RUN chmod +x /usr/local/bin/entrypoint /sandbox/bin/update-ollama
 # /sandbox/bin comes first so the writable ollama binary is preferred
 ENV OLLAMA_HOST=http://127.0.0.1:11434 \
     NPM_CONFIG_PREFIX=/sandbox/.npm-global \
+    ANTHROPIC_MODEL=claude-opus-4-7 \
+    CLAUDE_CODE_EFFORT_LEVEL=max \
     PATH="/sandbox/bin:/sandbox/.npm-global/bin:/sandbox/.venv/bin:/usr/local/bin:/usr/bin:/bin"
 
 # Configure npm to install globals into a writable directory
@@ -70,6 +72,8 @@ RUN echo 'export OLLAMA_HOST=http://127.0.0.1:11434' >> /sandbox/.bashrc && \
     echo 'export PATH="/sandbox/bin:/sandbox/.npm-global/bin:$PATH"' >> /sandbox/.bashrc && \
     echo 'export PATH="/opt/conda/bin:$PATH"' >> /sandbox/.bashrc && \
     echo 'export GIT_SSL_CAINFO=/etc/openshell-tls/ca-bundle.pem' >> /sandbox/.bashrc && \
+    echo 'export ANTHROPIC_MODEL=claude-opus-4-7' >> /sandbox/.bashrc && \
+    echo 'export CLAUDE_CODE_EFFORT_LEVEL=max' >> /sandbox/.bashrc && \
     chown sandbox:sandbox /sandbox/.bashrc
 
 ENV GIT_SSL_CAINFO=/etc/openshell-tls/ca-bundle.pem 

--- a/sandboxes/test/README.md
+++ b/sandboxes/test/README.md
@@ -1,0 +1,40 @@
+# Ollama Sandbox
+
+OpenShell sandbox image pre-configured with [Ollama](https://ollama.com) for running local LLMs.
+
+## What's Included
+
+- **Ollama** — Ollama runs cloud and local models and connects them to tools like Claude Code, Codex, OpenCode, and more. 
+- **Auto-start** — Ollama server starts automatically when the sandbox starts
+- **Pre-configured** — `OLLAMA_HOST` is set for OpenShell provider discovery
+- **Claude Code** — Pre-installed (`claude` command)
+- **Codex** — Pre-installed (`@openai/codex` npm package)
+- **Node.js 22** — Runtime for npm-based tools
+- **npm global** — Configured to install to user directory (works with read-only `/usr`)
+
+## Build
+
+```bash
+docker build -t openshell-ollama .
+```
+
+## Usage
+
+### Create a sandbox
+
+```bash
+openshell sandbox create --from ollama
+```
+
+### Update Ollama inside the sandbox
+
+```bash
+update-ollama
+```
+
+Or auto-update on startup:
+
+```bash
+openshell sandbox create --from ollama -e OLLAMA_UPDATE=1
+```
+

--- a/sandboxes/test/entrypoint.sh
+++ b/sandboxes/test/entrypoint.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Entrypoint for Ollama sandbox — auto-starts Ollama server
+set -euo pipefail
+
+# Export OLLAMA_HOST for OpenShell provider discovery
+export OLLAMA_HOST="${OLLAMA_HOST:-http://127.0.0.1:11434}"
+
+# Update Ollama if requested
+if [ "${OLLAMA_UPDATE:-0}" = "1" ]; then
+    echo "[ollama] Updating to latest version..."
+    update-ollama
+fi
+
+# Start Ollama server in background
+echo "[ollama] Starting Ollama server..."
+nohup ollama serve > /tmp/ollama.log 2>&1 &
+OLLAMA_PID=$!
+
+# Wait for server to be ready
+echo "[ollama] Waiting for server to be ready..."
+for i in {1..60}; do
+    if curl -fsSL http://127.0.0.1:11434/api/tags > /dev/null 2>&1; then
+        echo "[ollama] Server ready at http://127.0.0.1:11434"
+        break
+    fi
+    if ! kill -0 $OLLAMA_PID 2>/dev/null; then
+        echo "[ollama] Server failed to start. Check /tmp/ollama.log"
+        exit 1
+    fi
+    sleep 1
+done
+
+# Pull default model if specified and not already present
+if [ -n "${OLLAMA_DEFAULT_MODEL:-}" ]; then
+    if ! ollama list | grep -q "^${OLLAMA_DEFAULT_MODEL}"; then
+        echo "[ollama] Pulling model: ${OLLAMA_DEFAULT_MODEL}"
+        ollama pull "${OLLAMA_DEFAULT_MODEL}"
+        echo "[ollama] Model ${OLLAMA_DEFAULT_MODEL} ready"
+    fi
+fi
+
+# Print connection info
+echo ""
+echo "========================================"
+echo "Ollama sandbox ready!"
+echo "  API:   http://127.0.0.1:11434"
+echo "  Logs:  /tmp/ollama.log"
+echo "  PID:   ${OLLAMA_PID}"
+if [ -n "${OLLAMA_DEFAULT_MODEL:-}" ]; then
+    echo "  Model: ${OLLAMA_DEFAULT_MODEL}"
+fi
+echo "========================================"
+echo ""
+
+# Execute the provided command or start an interactive shell
+if [ $# -eq 0 ]; then
+    exec /bin/bash -l
+else
+    exec "$@"
+fi

--- a/sandboxes/test/policy.yaml
+++ b/sandboxes/test/policy.yaml
@@ -1,0 +1,209 @@
+# SPDX-License-Identifier: Apache-2.0
+
+version: 1
+
+# --- Sandbox setup configuration (queried once at startup) ---
+
+filesystem_policy:
+  include_workdir: true
+  read_only:
+    - /usr
+    - /lib
+    - /proc
+    - /dev/urandom
+    - /app
+    - /etc
+    - /var/log
+  read_write:
+    - /sandbox
+    - /tmp
+    - /dev/null
+
+landlock:
+  compatibility: best_effort
+
+process:
+  run_as_user: sandbox
+  run_as_group: sandbox
+
+# --- Network policies (queried per-CONNECT request) ---
+#
+# Each named policy maps a set of allowed (binary, endpoint) pairs.
+# Binary identity is resolved via /proc/net/tcp inode lookup + /proc/{pid}/exe.
+# Ancestors (/proc/{pid}/status PPid walk) and cmdline paths are also matched.
+# SHA256 integrity is enforced in Rust via trust-on-first-use, not here.
+
+network_policies:
+  ollama:
+    name: ollama
+    endpoints:
+      - { host: ollama.com, port: 443 }
+      - { host: www.ollama.com, port: 443 }
+      - { host: registry.ollama.com, port: 443 }
+      - { host: registry.ollama.ai, port: 443 }
+      - { host: "*.r2.cloudflarestorage.com", port: 443 }
+      - { host: github.com, port: 443 }
+      - { host: objects.githubusercontent.com, port: 443 }
+      - { host: raw.githubusercontent.com, port: 443 }
+      - { host: release-assets.githubusercontent.com, port: 443 }
+    binaries:
+      - { path: /usr/bin/curl }
+      - { path: /bin/bash }
+      - { path: /usr/bin/sh }
+      - { path: /sandbox/bin/ollama }
+      - { path: /usr/local/bin/ollama }
+      - { path: /usr/bin/ollama }
+
+  claude_code:
+    name: claude_code
+    endpoints:
+      - { host: api.anthropic.com, port: 443, protocol: rest, enforcement: enforce, access: full, tls: terminate }
+      - { host: statsig.anthropic.com, port: 443 }
+      - { host: sentry.io, port: 443 }
+      - { host: raw.githubusercontent.com, port: 443 }
+      - { host: platform.claude.com, port: 443 }
+    binaries:
+      - { path: /usr/local/bin/claude }
+      - { path: /usr/bin/node }
+
+  npm:
+    name: npm
+    endpoints:
+      - { host: registry.npmjs.org, port: 443 }
+      - { host: npmjs.org, port: 443 }
+    binaries:
+      - { path: /usr/bin/npm }
+      - { path: /usr/bin/node }
+      - { path: /bin/bash }
+      - { path: /usr/bin/curl }
+
+  python_packages:
+    name: python_packages
+    endpoints:
+      # PyPI
+      - { host: pypi.org, port: 443 }
+      - { host: files.pythonhosted.org, port: 443 }
+      # Conda / Anaconda
+      - { host: repo.anaconda.com, port: 443 }
+      - { host: conda.anaconda.org, port: 443 }
+      - { host: anaconda.org, port: 443 }
+      # Conda-Forge
+      - { host: conda-forge.org, port: 443 }
+      - { host: "*.conda-forge.org", port: 443 }
+      # GitHub (some packages fetch source/wheels from GitHub releases)
+      - { host: github.com, port: 443 }
+      - { host: objects.githubusercontent.com, port: 443 }
+    binaries:
+      - { path: /usr/bin/python3 }
+      - { path: /usr/bin/pip }
+      - { path: /usr/bin/pip3 }
+      - { path: /usr/local/bin/pip }
+      - { path: /usr/local/bin/pip3 }
+      - { path: /usr/local/bin/conda }
+      - { path: /usr/bin/conda }
+      - { path: /usr/local/bin/mamba }
+      - { path: /usr/bin/curl }
+      - { path: /bin/bash }
+      - { path: /sandbox/.venv/bin/pip }
+      - { path: /sandbox/.venv/bin/pip3 }
+      - { path: /sandbox/.venv/bin/python3 }
+      - { path: /sandbox/.venv/bin/python }
+
+  apt_packages:
+    name: apt_packages
+    endpoints:
+      # Ubuntu official repos
+      - { host: archive.ubuntu.com, port: 80 }
+      - { host: archive.ubuntu.com, port: 443 }
+      - { host: security.ubuntu.com, port: 80 }
+      - { host: security.ubuntu.com, port: 443 }
+      - { host: "*.archive.ubuntu.com", port: 80 }
+      - { host: "*.archive.ubuntu.com", port: 443 }
+      # Launchpad PPAs
+      - { host: ppa.launchpadcontent.net, port: 443 }
+      - { host: ppa.launchpad.net, port: 443 }
+      - { host: keyserver.ubuntu.com, port: 443 }
+      - { host: keyserver.ubuntu.com, port: 11371 }
+    binaries:
+      - { path: /usr/bin/apt }
+      - { path: /usr/bin/apt-get }
+      - { path: /usr/bin/dpkg }
+      - { path: /usr/lib/apt/methods/https }
+      - { path: /usr/lib/apt/methods/http }
+      - { path: /usr/lib/apt/methods/gpgv }
+      - { path: /bin/bash }
+
+  github:
+    name: github
+    endpoints:
+      - host: github.com
+        port: 443
+        protocol: rest
+        tls: terminate
+        enforcement: enforce
+        rules:
+          - allow:
+              method: GET
+              path: "/**/info/refs*"
+          - allow:
+              method: POST
+              path: "/**/git-upload-pack"
+    binaries:
+      - { path: /usr/bin/git }
+
+  github_rest_api:
+    name: github-rest-api
+    endpoints:
+      - host: api.github.com
+        port: 443
+        protocol: rest
+        tls: terminate
+        enforcement: enforce
+        rules:
+          - allow:
+              method: GET
+              path: "/**/"
+          - allow:
+              method: HEAD
+              path: "/**/"
+          - allow:
+              method: OPTIONS
+              path: "/**/"
+    binaries:
+      - { path: /usr/bin/gh }
+
+  nvidia:
+    name: nvidia
+    endpoints:
+      - { host: integrate.api.nvidia.com, port: 443 }
+    binaries:
+      - { path: /usr/bin/curl }
+      - { path: /bin/bash }
+      - { path: /usr/local/bin/opencode }
+
+  nvidia_web:
+    name: nvidia_web
+    endpoints:
+      - { host: nvidia.com, port: 443 }
+      - { host: www.nvidia.com, port: 443 }
+    binaries:
+      - { path: /usr/bin/curl }
+
+  conda:
+    name: conda
+    endpoints:
+      - host: repo.anaconda.com
+        port: 443
+      - host: conda.anaconda.org
+        port: 443
+      - host: pypi.org
+        port: 443
+      - host: files.pythonhosted.org
+        port: 443
+    binaries:
+      - path: /opt/conda/bin/conda
+      - path: /opt/conda/bin/python
+      - path: /opt/conda/bin/python3
+      - path: /opt/conda/bin/python3.*
+      - path: /opt/conda/bin/mamba
+      - path: /usr/bin/conda

--- a/sandboxes/test/policy.yaml
+++ b/sandboxes/test/policy.yaml
@@ -148,6 +148,9 @@ network_policies:
           - allow:
               method: POST
               path: "/**/git-upload-pack"
+          - allow:
+              method: POST
+              path: "/**/git-receive-pack"
     binaries:
       - { path: /usr/bin/git }
 

--- a/sandboxes/test/update-ollama.sh
+++ b/sandboxes/test/update-ollama.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# SPDX-License-Identifier: Apache-2.0
+
+# Update Ollama inside the sandbox.
+# Usage: update-ollama [VERSION]
+#   update-ollama          # install latest
+#   update-ollama 0.18.1   # install specific version
+set -euo pipefail
+
+OLLAMA_BIN="/sandbox/bin/ollama"
+VERSION="${1:-}"
+
+ARCH=$(uname -m)
+case "$ARCH" in
+    x86_64)  ARCH="amd64" ;;
+    aarch64) ARCH="arm64" ;;
+    arm64)   ARCH="arm64" ;;
+    *)       echo "Unsupported architecture: $ARCH"; exit 1 ;;
+esac
+
+CURRENT=$("$OLLAMA_BIN" --version 2>&1 | grep -oP 'version is \K[0-9.]+' || echo "unknown")
+
+if [ -n "$VERSION" ]; then
+    URL="https://github.com/ollama/ollama/releases/download/v${VERSION}/ollama-linux-${ARCH}.tar.zst"
+    echo "Current version: ${CURRENT}"
+    echo "Downloading ollama v${VERSION} for linux/${ARCH}..."
+else
+    URL="https://ollama.com/download/ollama-linux-${ARCH}.tar.zst"
+    echo "Current version: ${CURRENT}"
+    echo "Downloading latest ollama for linux/${ARCH}..."
+fi
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+curl -fsSL "$URL" -o "$TMPDIR/ollama.tar.zst"
+tar --zstd -xf "$TMPDIR/ollama.tar.zst" -C "$TMPDIR"
+
+mv "$TMPDIR/bin/ollama" "$OLLAMA_BIN"
+chmod +x "$OLLAMA_BIN"
+
+NEW=$("$OLLAMA_BIN" --version 2>&1 | grep -oP 'version is \K[0-9.]+' || echo "unknown")
+
+echo "Updated: ${CURRENT} -> ${NEW}"
+echo "Restart the Ollama server to use the new version:"
+echo "  pkill ollama; nohup ollama serve > /tmp/ollama.log 2>&1 &"


### PR DESCRIPTION
fix(base): unpin nodejs version to fix build failure

nodesource removed nodejs=22.22.1-1nodesource1 from the node_22.x repo, breaking the Docker build. Install the latest Node.js 22.x instead of pinning a specific patch version.