### PR TITLE
Add Reach sandbox — AI-native remote server management

### DIFF
--- a/sandboxes/reach/Dockerfile
+++ b/sandboxes/reach/Dockerfile
@@ -1,0 +1,33 @@
+# syntax=docker/dockerfile:1
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 agent-0x
+# SPDX-License-Identifier: Apache-2.0
+
+# OpenShell Reach sandbox
+#
+# Provides the reach CLI for AI-native remote server management.
+# Reach replaces SSH with HTTPS+Token, purpose-built for AI agents.
+#
+# Build:  docker build -t openshell-reach .
+
+FROM ghcr.io/nvidia/openshell-community/base:latest
+
+ARG REACH_VERSION=0.2.0
+ARG TARGETARCH=amd64
+
+# Install reach binary
+RUN curl -fsSL "https://github.com/agent-0x/reach/releases/download/v${REACH_VERSION}/reach_${REACH_VERSION}_linux_${TARGETARCH}.tar.gz" \
+    -o /tmp/reach.tar.gz \
+    && tar xzf /tmp/reach.tar.gz -C /tmp \
+    && mv /tmp/reach /usr/local/bin/reach \
+    && chmod +x /usr/local/bin/reach \
+    && rm /tmp/reach.tar.gz
+
+# Verify installation
+RUN reach --help > /dev/null
+
+# Create reach config directory for sandbox user
+RUN mkdir -p /sandbox/.reach && chown sandbox:sandbox /sandbox/.reach
+
+USER sandbox
+WORKDIR /sandbox

--- a/sandboxes/reach/README.md
+++ b/sandboxes/reach/README.md
@@ -1,0 +1,66 @@
+# Reach Sandbox
+
+AI-native remote server management — no SSH required.
+
+[Reach](https://github.com/agent-0x/reach) replaces SSH with HTTPS + Token for AI agents. One binary on the server, one token to connect. Built-in MCP server for Claude Code, Cursor, and any MCP-compatible AI.
+
+## What's Included
+
+- **reach CLI** (`/usr/local/bin/reach`) — manage remote servers
+- **MCP server** — `reach mcp serve` for AI agent integration
+- **Network policy** — allows reach-agent connections (port 7100/TLS) and GitHub API
+
+## Quick Start
+
+### 1. Configure servers
+
+Add your reach-agent servers inside the sandbox:
+
+```bash
+reach add myserver --host 203.0.113.10 --token <token>
+```
+
+### 2. Use with Claude Code
+
+```bash
+reach mcp install
+# Restart Claude Code — reach tools are now available
+```
+
+### 3. Direct CLI usage
+
+```bash
+reach exec myserver "uname -a"
+reach stats myserver
+reach dryrun myserver "rm -rf /opt/old"
+```
+
+## Network Policy
+
+The included `policy.yaml` allows:
+
+| Policy | What | Why |
+|--------|------|-----|
+| `reach-agent` | `*:7100` (TLS passthrough) | Connect to reach agents |
+| `reach-github` | `api.github.com`, `github.com` | Bootstrap + release downloads |
+| `claude-code` | `api.anthropic.com` + related | Claude Code MCP integration |
+
+**For production:** Replace the wildcard `*:7100` entry with your actual server IPs.
+
+## MCP Tools Available
+
+| Tool | Description |
+|------|-------------|
+| `reach_bash` | Execute a shell command on a remote server |
+| `reach_read` | Read a remote file |
+| `reach_write` | Write a file (atomic) |
+| `reach_upload` | Upload a local file |
+| `reach_stats` | Get structured system stats (CPU, memory, disk, network) |
+| `reach_dryrun` | Check command risk before executing |
+| `reach_info` | Get system info |
+| `reach_list` | List configured servers |
+
+## Links
+
+- [Reach GitHub](https://github.com/agent-0x/reach)
+- [Reach Documentation](https://github.com/agent-0x/reach#readme)

--- a/sandboxes/reach/policy.yaml
+++ b/sandboxes/reach/policy.yaml
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 agent-0x
+# SPDX-License-Identifier: Apache-2.0
+
+version: 1
+
+# Reach sandbox — AI-native remote server management
+#
+# Reach replaces SSH with HTTPS+Token for AI agents. This policy allows
+# the reach binary to connect to remote reach-agent instances over TLS,
+# and permits downloading releases from GitHub for bootstrap/updates.
+
+filesystem_policy:
+  include_workdir: true
+  read_only:
+    - /usr
+    - /lib
+    - /proc
+    - /dev/urandom
+    - /app
+    - /etc
+    - /var/log
+  read_write:
+    - /sandbox
+    - /tmp
+    - /dev/null
+
+landlock:
+  compatibility: best_effort
+
+process:
+  run_as_user: sandbox
+  run_as_group: sandbox
+
+network_policies:
+  # Reach agent connections — HTTPS to remote servers on the default agent port.
+  # In production, list your actual server IPs/hostnames explicitly.
+  # The wildcard entry below is a starting template; narrow it to your fleet.
+  reach_agent:
+    name: reach-agent
+    endpoints:
+      # Example: allow reach to connect to any host on the agent port (TLS).
+      # Replace with your actual server addresses for production use:
+      #   - { host: 152.53.34.214, port: 7100, protocol: rest, tls: passthrough }
+      #   - { host: 152.53.45.129, port: 7100, protocol: rest, tls: passthrough }
+      - host: "*"
+        port: 7100
+        protocol: rest
+        tls: passthrough
+        enforcement: enforce
+    binaries:
+      - { path: /usr/local/bin/reach }
+
+  # GitHub API — for `reach bootstrap` (fetch latest release) and install script
+  reach_github:
+    name: reach-github
+    endpoints:
+      - { host: api.github.com, port: 443 }
+      - { host: github.com, port: 443 }
+      - { host: objects.githubusercontent.com, port: 443 }
+    binaries:
+      - { path: /usr/local/bin/reach }
+      - { path: /usr/bin/curl }
+
+  # Claude Code — if using reach as an MCP server within Claude Code
+  claude_code:
+    name: claude-code
+    endpoints:
+      - { host: api.anthropic.com, port: 443, protocol: rest, enforcement: enforce, access: full, tls: terminate }
+      - { host: statsig.anthropic.com, port: 443 }
+      - { host: sentry.io, port: 443 }
+      - { host: raw.githubusercontent.com, port: 443 }
+      - { host: platform.claude.com, port: 443 }
+    binaries:
+      - { path: /usr/local/bin/claude }
+      - { path: /usr/bin/node }


### PR DESCRIPTION
## Summary

- Adds a new `sandboxes/reach/` sandbox providing the [Reach](https://github.com/agent-0x/reach) CLI for AI-native remote server management
- Reach replaces SSH with HTTPS + Token, purpose-built for AI agents
- Includes Dockerfile, network policy, and README

## What is Reach?

Reach is a lightweight agent that runs on remote servers (single Go binary, ~9MB). AI agents connect via HTTPS + Bearer Token through a built-in MCP server — no SSH keys, no shell parsing, just structured JSON.

**Key differentiators from SSH:**
- Structured JSON responses (AI can parse directly)
- Command risk scoring (`reach_dryrun`) before execution
- One-command deployment (`reach bootstrap`)
- Built-in MCP server for Claude Code, Cursor, Windsurf

## Files

| File | Purpose |
|------|---------|
| `sandboxes/reach/Dockerfile` | Installs reach v0.2.0 from GitHub Releases |
| `sandboxes/reach/policy.yaml` | Network policy: reach-agent (7100/TLS), GitHub API, Claude Code |
| `sandboxes/reach/README.md` | Quick start, MCP tools reference |

## Network Policy

| Policy | Endpoints | Purpose |
|--------|-----------|---------|
| `reach-agent` | `*:7100` (TLS passthrough) | Connect to remote reach agents |
| `reach-github` | `api.github.com`, `github.com` | Bootstrap + release downloads |
| `claude-code` | `api.anthropic.com` + related | Claude Code MCP integration |

## Test Plan

- [ ] `docker build -t openshell-reach sandboxes/reach/` builds successfully
- [ ] `reach --help` works inside container
- [ ] Network policy validates against OpenShell policy schema