### PR TITLE
feat(policy): add GitHub Copilot API endpoints to base sandbox policy

### DIFF
--- a/sandboxes/base/Dockerfile
+++ b/sandboxes/base/Dockerfile
@@ -75,7 +75,7 @@ RUN npm install -g \
         @hono/node-server@1.19.11 \
         opencode-ai@1.2.18 \
         @openai/codex@0.117.0 \
-        @github/copilot@1.0.9
+        @github/copilot@1.0.16
 
 # GitHub CLI
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \

--- a/sandboxes/base/policy.yaml
+++ b/sandboxes/base/policy.yaml
@@ -95,6 +95,30 @@ network_policies:
       - { path: /usr/local/bin/claude }
       - { path: /usr/bin/gh }
 
+  # --- GitHub Copilot API ---
+  # Endpoints from https://docs.github.com/en/copilot/reference/copilot-allowlist-reference
+  copilot:
+    name: copilot
+    endpoints:
+      # Auth and user management
+      - { host: github.com, port: 443 }
+      - { host: api.github.com, port: 443 }
+      # Copilot API (subscription-tier routing)
+      - { host: api.githubcopilot.com, port: 443, protocol: rest, enforcement: enforce, access: read-write }
+      - { host: api.individual.githubcopilot.com, port: 443, protocol: rest, enforcement: enforce, access: read-write }
+      - { host: api.business.githubcopilot.com, port: 443, protocol: rest, enforcement: enforce, access: read-write }
+      - { host: api.enterprise.githubcopilot.com, port: 443, protocol: rest, enforcement: enforce, access: read-write }
+      # Model proxy
+      - { host: copilot-proxy.githubusercontent.com, port: 443, protocol: rest, enforcement: enforce, access: read-write }
+      # Telemetry, feature flags, updates
+      - { host: origin-tracker.githubusercontent.com, port: 443 }
+      - { host: telemetry.enterprise.githubcopilot.com, port: 443 }
+      - { host: default.exp-tas.com, port: 443 }
+      - { host: release-assets.githubusercontent.com, port: 443 }
+    binaries:
+      - { path: /usr/bin/copilot }
+      - { path: "/usr/lib/node_modules/@github/copilot/node_modules/@github/**/copilot" }
+
   pypi:
     name: pypi
     endpoints:
@@ -159,19 +183,6 @@ network_policies:
     - path: /usr/lib/node_modules/opencode-ai/bin/.opencode
     - path: /usr/bin/node
     - path: /usr/local/bin/opencode
-
-  copilot:
-    name: copilot
-    endpoints:
-    - { host: github.com, port: 443 }
-    - { host: api.github.com, port: 443 }
-    - { host: api.githubcopilot.com, port: 443 }
-    - { host: api.enterprise.githubcopilot.com, port: 443 }
-    - { host: release-assets.githubusercontent.com, port: 443 }
-    - { host: copilot-proxy.githubusercontent.com, port: 443 }
-    - { host: default.exp-tas.com, port: 443 }
-    binaries:
-    - { path: /usr/lib/node_modules/@github/copilot/node_modules/@github/**/copilot }
 
   codex:
     name: codex


### PR DESCRIPTION
## Summary

Adds GitHub Copilot API endpoints to the base sandbox policy, enabling Copilot CLI to run inside OpenShell sandboxes with L7 proxy credential injection.

## Changes

### New: `copilot_api` policy
- All endpoints from [GitHub's official Copilot allowlist reference](https://docs.github.com/en/copilot/reference/copilot-allowlist-reference):
  - `api.githubcopilot.com` — default Copilot API
  - `api.individual/business/enterprise.githubcopilot.com` — subscription-tier routing
  - `copilot-proxy.githubusercontent.com` — model proxy
  - `origin-tracker.githubusercontent.com` — tracking
  - `telemetry.enterprise.githubcopilot.com` — telemetry
  - `default.exp-tas.com` — feature flags
  - `release-assets.githubusercontent.com` — binary updates
- L7 inspection enabled (`protocol: rest`, `tls: terminate`) on API endpoints for credential injection
- Binary paths: `/usr/bin/node`, `/usr/bin/copilot`, `/usr/lib/node_modules/**`

### Updated: `github_rest_api` policy
- Added `node`, `copilot`, and `node_modules` binary paths so Copilot can access the GitHub API

### Updated: `github_ssh_over_https` policy
- Added `node`, `copilot`, `node_modules`, and `git-core` binary paths for Copilot git operations

### Removed: old `copilot` policy
- Replaced by the more complete `copilot_api` policy (old one lacked L7 config, missing subscription-tier endpoints)

## Testing

Verified end-to-end in a live OpenShell sandbox:
- Copilot CLI authenticates via proxy credential injection ✅
- `/models` endpoint returns available models ✅
- `/chat/completions` inference calls succeed ✅
- `/mcp/readonly` MCP calls succeed ✅
- Zero policy denials ✅

## Related

- [NVIDIA/OpenShell PR #476](https://github.com/NVIDIA/OpenShell/pull/476) — Copilot provider support
- [NVIDIA/OpenShell Issue #707](https://github.com/NVIDIA/OpenShell/issues/707) — Copilot CLI enum fix
- [github/copilot-cli#2431](https://github.com/github/copilot-cli/issues/2431) — Copilot CLI client-side token validation