### PR TITLE
refactor(base): add nftables package for bypass detection

### DIFF
--- a/sandboxes/base/Dockerfile
+++ b/sandboxes/base/Dockerfile
@@ -21,7 +21,8 @@ WORKDIR /sandbox
 
 # Core system dependencies
 # iproute2: network namespace management (ip netns, veth pairs)
-# iptables: bypass detection — LOG + REJECT rules for direct connection diagnostics
+# iptables: legacy bypass detection (kept for transition)
+# nftables: bypass detection — log + reject rules for direct connection diagnostics
 # dnsutils: dig, nslookup
 # Python is managed entirely by uv (see devtools stage).
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -30,6 +31,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         dnsutils \
         iproute2 \
         iptables \
+        nftables \
         iputils-ping \
         net-tools \
         netcat-openbsd \


### PR DESCRIPTION
## Summary

- Add `nftables` package to the sandbox base image alongside `iptables`
- The sandbox supervisor is migrating from iptables to nftables for bypass detection rules ([NVIDIA/OpenShell#1335](https://github.com/NVIDIA/OpenShell/issues/1335))
- Both packages are installed during the transition period; `iptables` can be removed in a future release

## Test plan

- [x] Build the image locally and verify `nft` is available
- [x] Run the OpenShell e2e bypass detection test against a gateway using this image — passes in ~1.5s