### PR TITLE
feat(sandboxes): add Kiro CLI sandbox image

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This repo is the community ecosystem around OpenShell -- a hub for contributed s
 | `sandboxes/base/`       | Foundational image with system tools, users, and dev environment |
 | `sandboxes/droid/`      | Android automation and mobile testing workflows              |
 | `sandboxes/gemini/`     | Gemini CLI workflows                                         |
+| `sandboxes/kiro/`       | Kiro CLI for AI-powered agentic code generation and review   |
 | `sandboxes/nvidia-gpu/` | GPU-enabled VM sandbox image with NVIDIA userspace tooling   |
 | `sandboxes/ollama/`     | Ollama for local and cloud LLMs with Claude Code, Codex, OpenCode pre-installed |
 | `sandboxes/sdg/`        | Synthetic data generation workflows                          |
@@ -57,6 +58,18 @@ curl http://127.0.0.1:11434/api/tags
 ```
 
 See the [Ollama sandbox README](sandboxes/ollama/README.md) for full details.
+
+### Kiro Sandbox
+
+The Kiro sandbox provides [Kiro CLI](https://kiro.dev) for AI-powered agentic code generation, review, and infrastructure management.
+
+**Quick start:**
+
+```bash
+openshell sandbox create --from kiro -e KIRO_API_KEY=<your-key>
+```
+
+Requires a Kiro Pro, Pro+, or Power subscription. See the [Kiro sandbox README](sandboxes/kiro/README.md) for full details.
 
 ## Contributing
 

--- a/sandboxes/kiro/Dockerfile
+++ b/sandboxes/kiro/Dockerfile
@@ -1,0 +1,32 @@
+# syntax=docker/dockerfile:1.4
+
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Kiro CLI sandbox image for OpenShell
+#
+# Builds on the community base sandbox and adds AWS Kiro CLI.
+# Build:  docker build -t openshell-kiro --build-arg BASE_IMAGE=openshell-base .
+# Run:    openshell sandbox create --from kiro
+
+ARG BASE_IMAGE=ghcr.io/nvidia/openshell-community/sandboxes/base:latest
+FROM ${BASE_IMAGE}
+
+USER root
+
+# Install Kiro CLI (latest via official installer)
+RUN apt-get update && apt-get install -y --no-install-recommends unzip \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -fsSL https://cli.kiro.dev/install | bash \
+    && cp /root/.local/bin/kiro-cli /usr/local/bin/kiro \
+    && chmod 755 /usr/local/bin/kiro
+
+# Copy sandbox policy
+COPY policy.yaml /etc/openshell/policy.yaml
+
+# Create Kiro config directory
+RUN mkdir -p /sandbox/.kiro && chown sandbox:sandbox /sandbox/.kiro
+
+USER sandbox
+
+ENTRYPOINT ["/bin/bash"]

--- a/sandboxes/kiro/README.md
+++ b/sandboxes/kiro/README.md
@@ -1,0 +1,58 @@
+# Kiro CLI Sandbox
+
+Secure sandbox environment for running [Kiro CLI](https://kiro.dev) — an AI-powered
+agentic command-line interface for code generation, review, and infrastructure
+management.
+
+## What's Included
+
+| Tool | Version | Notes |
+|------|---------|-------|
+| Kiro CLI | latest | Installed via official installer |
+
+All tools from the [base sandbox](../base/) are also available (Python, Node.js,
+git, gh, etc.).
+
+## Usage
+
+```bash
+openshell sandbox create --from kiro
+```
+
+### Authentication
+
+Kiro CLI requires a Kiro Pro, Pro+, or Power subscription for headless API key
+authentication. Generate a key at <https://app.kiro.dev>, then pass it when
+creating the sandbox:
+
+```bash
+openshell sandbox create --from kiro -e KIRO_API_KEY=<your-key>
+```
+
+Inside the sandbox, run `kiro` to start an interactive session.
+
+## Build
+
+```bash
+docker build -t openshell-kiro --build-arg BASE_IMAGE=ghcr.io/nvidia/openshell-community/sandboxes/base:latest .
+```
+
+## Network Policies
+
+| Policy | Allowed Endpoints |
+|--------|-------------------|
+| kiro-cli | `*.kiro.dev:443`, `*.amazoncodewhisperer.com:443` |
+| github-ssh-over-https | `github.com:443` (git fetch/clone) |
+| github-rest-api | `api.github.com:443` (read + PR creation) |
+| pypi | `pypi.org:443`, `files.pythonhosted.org:443` |
+| npm | `registry.npmjs.org:443` |
+
+All other outbound connections are denied by policy.
+
+## Examples
+
+### ECS Fargate Deployment
+
+Run Kiro as a headless HTTP service on AWS ECS Fargate. See
+[`examples/ecs/`](examples/ecs/) for the Dockerfile variant, HTTP server, task
+definition, and step-by-step deployment instructions.

--- a/sandboxes/kiro/examples/ecs/Dockerfile.ecs
+++ b/sandboxes/kiro/examples/ecs/Dockerfile.ecs
@@ -1,0 +1,32 @@
+# syntax=docker/dockerfile:1.4
+
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Kiro CLI sandbox — ECS Fargate deployment variant
+#
+# Adds an HTTP API wrapper for running Kiro as a headless service.
+# Build:  docker build -f Dockerfile.ecs -t kiro-sandbox-ecs .
+# Deploy: See README.md for ECS task definition and Terraform examples.
+
+ARG BASE_IMAGE=ghcr.io/nvidia/openshell-community/sandboxes/base:latest
+FROM ${BASE_IMAGE}
+
+USER root
+
+RUN apt-get update && apt-get install -y --no-install-recommends python3 unzip \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -fsSL https://cli.kiro.dev/install | bash \
+    && cp /root/.local/bin/kiro-cli /usr/local/bin/kiro \
+    && chmod 755 /usr/local/bin/kiro
+
+COPY policy.yaml /etc/openshell/policy.yaml
+COPY examples/ecs/server.py /usr/local/bin/server.py
+RUN chmod +x /usr/local/bin/server.py
+
+RUN mkdir -p /sandbox/.kiro && chown sandbox:sandbox /sandbox/.kiro
+
+USER sandbox
+EXPOSE 8080
+
+CMD ["python3", "/usr/local/bin/server.py"]

--- a/sandboxes/kiro/examples/ecs/README.md
+++ b/sandboxes/kiro/examples/ecs/README.md
@@ -1,0 +1,89 @@
+# ECS Deployment Example
+
+Run the Kiro sandbox as a headless HTTP service on AWS ECS Fargate.
+
+## Architecture
+
+The ECS variant wraps Kiro CLI in a lightweight Python HTTP server (`server.py`)
+that accepts prompts via POST and returns clean JSON responses. The API key is
+injected from AWS Secrets Manager at task startup.
+
+```
+Client → POST :8080 {"command": "..."} → Kiro CLI → JSON response
+```
+
+## Prerequisites
+
+- AWS account with ECS, ECR, and Secrets Manager access
+- Kiro API key stored in Secrets Manager
+
+## Setup
+
+### 1. Store your API key
+
+```bash
+aws secretsmanager create-secret \\
+  --name kiro-sandbox/api-key \\
+  --secret-string "<your-kiro-api-key>" \\
+  --region us-east-1
+```
+
+### 2. Create ECR repository
+
+```bash
+aws ecr create-repository --repository-name kiro-sandbox --region us-east-1
+```
+
+### 3. Build and push
+
+```bash
+# From the sandboxes/kiro/ directory
+docker build -f examples/ecs/Dockerfile.ecs -t kiro-sandbox-ecs .
+docker tag kiro-sandbox-ecs:latest <ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com/kiro-sandbox:latest
+
+aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin <ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com
+docker push <ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com/kiro-sandbox:latest
+```
+
+### 4. Deploy
+
+Edit `task-definition.json` — replace `ACCOUNT_ID` and `REGION` with your values.
+
+```bash
+aws ecs create-cluster --cluster-name kiro-sandbox --region us-east-1
+
+aws ecs register-task-definition --cli-input-json file://task-definition.json --region us-east-1
+
+aws ecs run-task \\
+  --cluster kiro-sandbox \\
+  --task-definition kiro-sandbox \\
+  --launch-type FARGATE \\
+  --network-configuration 'awsvpcConfiguration={subnets=["subnet-xxx"],securityGroups=["sg-xxx"],assignPublicIp=ENABLED}' \\
+  --region us-east-1
+```
+
+### 5. Use
+
+```bash
+# Health check
+curl http://<TASK_IP>:8080/health
+
+# Send a prompt
+curl -X POST http://<TASK_IP>:8080 \\
+  -H "Content-Type: application/json" \\
+  -d '{"command": "write a python function to reverse a string"}'
+```
+
+## API
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/health` | GET | Returns `{"status": "healthy"}` |
+| `/` | GET | Returns usage info |
+| `/` | POST | Accepts `{"command": "..."}`, returns `{"response": "...", "exit_code": 0}` |
+
+## Security Notes
+
+- The API key is injected via Secrets Manager — never baked into the image
+- The security group should restrict inbound 8080 to trusted CIDRs
+- For production, add an ALB with TLS termination in front of the task

--- a/sandboxes/kiro/examples/ecs/server.py
+++ b/sandboxes/kiro/examples/ecs/server.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Minimal HTTP wrapper around Kiro CLI for ECS/Fargate deployment."""
+import subprocess
+import json
+import os
+import re
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+PORT = int(os.environ.get("PORT", "8080"))
+
+ANSI_RE = re.compile(r'\x1b\[[0-9;]*[a-zA-Z]|\x1b\[\?[0-9;]*[a-zA-Z]|\x1b\[[0-9]*G|\x1b\(B|\x1b\[m')
+BRAILLE_RANGE = range(0x2800, 0x28FF + 1)
+
+
+def strip_ansi(text):
+    return ANSI_RE.sub('', text)
+
+
+def is_noise_line(line):
+    stripped = line.strip()
+    if not stripped:
+        return True
+    if any(ord(c) in BRAILLE_RANGE for c in stripped):
+        return True
+    if 'Thinking...' in stripped:
+        return True
+    if re.match(r'^[\d%\s>]+$', stripped):
+        return True
+    noise_markers = [
+        'Jump into building with Kiro', '/context add', '/mcp', '/help',
+        '/model', '/usage', '/quit', 'Credits:', 'To exit the CLI',
+        'Ask a question', 'Connect to external tools', 'Model:', 'Plan:',
+    ]
+    return any(marker in stripped for marker in noise_markers)
+
+
+def clean_output(text):
+    cleaned = strip_ansi(text)
+    cleaned = re.sub(r'[^\x20-\x7E\n]', '', cleaned)
+    cleaned = re.sub(r'\d+%\s*>', '', cleaned)
+    cleaned = re.sub(r'\s*>\s*$', '', cleaned, flags=re.MULTILINE)
+    lines = cleaned.split('\n')
+    result_lines = []
+    for line in lines:
+        if not is_noise_line(line):
+            content = line.strip()
+            if content.startswith('> '):
+                content = content[2:]
+            if content:
+                result_lines.append(content)
+    return '\n'.join(result_lines).strip()
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == "/health":
+            self._respond(200, {"status": "healthy"})
+        else:
+            self._respond(200, {"service": "kiro-sandbox", "usage": "POST / with {\"command\": \"...\"}"})
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        body = json.loads(self.rfile.read(length)) if length else {}
+        command = body.get("command", "")
+        if not command:
+            self._respond(400, {"error": "missing 'command' field"})
+            return
+        try:
+            result = subprocess.run(
+                ["kiro", "chat", command],
+                capture_output=True, text=True, timeout=120,
+                env={**os.environ, "NO_COLOR": "1", "TERM": "dumb"}
+            )
+            self._respond(200, {"response": clean_output(result.stdout), "exit_code": result.returncode})
+        except subprocess.TimeoutExpired:
+            self._respond(504, {"error": "command timed out (120s)"})
+
+    def _respond(self, code, data):
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(data).encode())
+
+    def log_message(self, format, *args):
+        pass
+
+
+if __name__ == "__main__":
+    print(f"Kiro sandbox API listening on :{PORT}")
+    HTTPServer(("0.0.0.0", PORT), Handler).serve_forever()

--- a/sandboxes/kiro/examples/ecs/task-definition.json
+++ b/sandboxes/kiro/examples/ecs/task-definition.json
@@ -1,0 +1,37 @@
+{
+  "family": "kiro-sandbox",
+  "requiresCompatibilities": ["FARGATE"],
+  "networkMode": "awsvpc",
+  "cpu": "512",
+  "memory": "1024",
+  "executionRoleArn": "arn:aws:iam::ACCOUNT_ID:role/kiro-sandbox-task-execution",
+  "taskRoleArn": "arn:aws:iam::ACCOUNT_ID:role/kiro-sandbox-task",
+  "containerDefinitions": [
+    {
+      "name": "kiro",
+      "image": "ACCOUNT_ID.dkr.ecr.REGION.amazonaws.com/kiro-sandbox:latest",
+      "essential": true,
+      "command": ["python3", "/usr/local/bin/server.py"],
+      "portMappings": [
+        { "containerPort": 8080, "protocol": "tcp" }
+      ],
+      "secrets": [
+        {
+          "name": "KIRO_API_KEY",
+          "valueFrom": "arn:aws:secretsmanager:REGION:ACCOUNT_ID:secret:kiro-sandbox/api-key"
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/kiro-sandbox",
+          "awslogs-region": "REGION",
+          "awslogs-stream-prefix": "kiro"
+        }
+      },
+      "linuxParameters": {
+        "initProcessEnabled": true
+      }
+    }
+  ]
+}

--- a/sandboxes/kiro/policy.yaml
+++ b/sandboxes/kiro/policy.yaml
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+version: 1
+
+# --- Sandbox setup configuration (queried once at startup) ---
+
+filesystem_policy:
+  include_workdir: true
+  read_only:
+    - /usr
+    - /lib
+    - /proc
+    - /dev/urandom
+    - /app
+    - /etc
+    - /var/log
+  read_write:
+    - /sandbox
+    - /tmp
+    - /dev/null
+
+landlock:
+  compatibility: best_effort
+
+process:
+  run_as_user: sandbox
+  run_as_group: sandbox
+
+# --- Network policies (queried per-CONNECT request) ---
+
+network_policies:
+  kiro_cli:
+    name: kiro-cli
+    endpoints:
+      - { host: "*.kiro.dev", port: 443 }
+      - { host: "*.amazoncodewhisperer.com", port: 443 }
+    binaries:
+      - { path: /usr/local/bin/kiro }
+      - { path: /usr/bin/curl }
+      - { path: /bin/bash }
+
+  github_ssh_over_https:
+    name: github-ssh-over-https
+    endpoints:
+      - host: github.com
+        port: 443
+        protocol: rest
+        tls: terminate
+        enforcement: enforce
+        rules:
+          - allow:
+              method: GET
+              path: "/**/info/refs*"
+          - allow:
+              method: POST
+              path: "/**/git-upload-pack"
+    binaries:
+      - { path: /usr/bin/git }
+
+  github_rest_api:
+    name: github-rest-api
+    endpoints:
+      - host: api.github.com
+        port: 443
+        protocol: rest
+        tls: terminate
+        enforcement: enforce
+        access: read-only
+    binaries:
+      - { path: /usr/local/bin/kiro }
+      - { path: /usr/bin/gh }
+
+  pypi:
+    name: pypi
+    endpoints:
+      - { host: pypi.org, port: 443 }
+      - { host: files.pythonhosted.org, port: 443 }
+      - { host: github.com, port: 443 }
+      - { host: objects.githubusercontent.com, port: 443 }
+      - { host: api.github.com, port: 443 }
+      - { host: downloads.python.org, port: 443 }
+    binaries:
+      - { path: /sandbox/.venv/bin/python }
+      - { path: /sandbox/.venv/bin/python3 }
+      - { path: /sandbox/.venv/bin/pip }
+      - { path: /usr/local/bin/uv }
+      - { path: "/sandbox/.uv/python/**" }
+
+  npm:
+    name: npm
+    endpoints:
+      - { host: registry.npmjs.org, port: 443 }
+    binaries:
+      - { path: /usr/bin/node }
+      - { path: /usr/bin/npm }


### PR DESCRIPTION
## Summary

Adds a Kiro CLI sandbox image for running [Kiro](https://kiro.dev) — an AI-powered agentic CLI for code generation, review, and infrastructure management — within OpenShell's sandboxed execution environment.

## What's included

```
sandboxes/kiro/
├── Dockerfile          # Installs Kiro CLI on the community base image
├── policy.yaml         # Network policies for kiro.dev, GitHub, PyPI, npm
├── README.md           # Usage, auth, build instructions
└── examples/
    └── ecs/            # ECS Fargate deployment example
        ├── Dockerfile.ecs
        ├── server.py
        ├── task-definition.json
        └── README.md
```

## Testing

- ✅ `docker build` completes successfully (tested via AWS CodeBuild and Colima)
- ✅ `kiro --version` returns `kiro-cli 2.3.0` inside the container
- ✅ `openshell sandbox create --from ./sandboxes/kiro -- kiro --version` works end-to-end
- ✅ ECS deployment tested — HTTP API responds with clean JSON
- ✅ Policy YAML structure matches the accepted Gemini sandbox pattern

## Network policies

| Policy | Endpoints |
|--------|-----------|
| kiro-cli | `*.kiro.dev:443`, `*.amazoncodewhisperer.com:443` |
| github-ssh-over-https | `github.com:443` (read-only git) |
| github-rest-api | `api.github.com:443` (read-only) |
| pypi | `pypi.org:443`, `files.pythonhosted.org:443` |
| npm | `registry.npmjs.org:443` |

## Notes

- Kiro CLI installer does not support version pinning — installs latest at build time
- Requires `unzip` (not in base image) as a build dependency
- API key auth requires Kiro Pro/Pro+/Power subscription
- The `examples/ecs/` directory shows how to run Kiro as a headless HTTP service on AWS Fargate