### PR TITLE
feat(sandbox): add pi sandbox image

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This repo is the community ecosystem around OpenShell -- a hub for contributed s
 | `sandboxes/gemini/`     | Gemini CLI workflows                                         |
 | `sandboxes/nvidia-gpu/` | GPU-enabled VM sandbox image with NVIDIA userspace tooling   |
 | `sandboxes/ollama/`     | Ollama for local and cloud LLMs with Claude Code, Codex, OpenCode pre-installed |
+| `sandboxes/pi/`         | [Pi](https://pi.dev) pre-installed                           |
 | `sandboxes/sdg/`        | Synthetic data generation workflows                          |
 
 ## Getting Started

--- a/sandboxes/pi/Dockerfile
+++ b/sandboxes/pi/Dockerfile
@@ -1,0 +1,25 @@
+# syntax=docker/dockerfile:1.4
+
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Pi Coding Agent sandbox image for OpenShell
+#
+# Builds on the community base sandbox and adds pi.
+# Build:  docker build -t openshell-pi --build-arg BASE_IMAGE=openshell-base .
+# Run:    openshell sandbox create --from pi
+
+ARG BASE_IMAGE=ghcr.io/nvidia/openshell-community/sandboxes/base:latest
+FROM ${BASE_IMAGE}
+
+USER root
+
+# Install pi
+RUN npm install -g @earendil-works/pi-coding-agent
+
+# Copy sandbox policy
+COPY policy.yaml /etc/openshell/policy.yaml
+
+USER sandbox
+
+ENTRYPOINT ["/bin/bash"]

--- a/sandboxes/pi/README.md
+++ b/sandboxes/pi/README.md
@@ -1,0 +1,43 @@
+# Pi Sandbox
+
+OpenShell sandbox image pre-configured with [pi](https://github.com/earendil-works/pi) — a minimal terminal coding harness.
+
+## What's Included
+
+- **pi**
+- Everything from the [base sandbox](../base/README.md)
+
+## Build
+
+```bash
+docker build -t openshell-pi .
+```
+
+To build against a specific base image:
+
+```bash
+docker build -t openshell-pi --build-arg BASE_IMAGE=ghcr.io/nvidia/openshell-community/sandboxes/base:latest .
+```
+
+## Usage
+
+### Create a sandbox
+
+```bash
+openshell sandbox create --from pi
+```
+
+### Run a specific pi command
+
+```bash
+openshell sandbox create --from pi -- pi --version
+```
+
+## Provider Setup
+
+Use `/login` in interactive mode, or set an API-key environment variable before starting pi, for example:
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+pi
+```

--- a/sandboxes/pi/README.md
+++ b/sandboxes/pi/README.md
@@ -27,17 +27,8 @@ docker build -t openshell-pi --build-arg BASE_IMAGE=ghcr.io/nvidia/openshell-com
 openshell sandbox create --from pi
 ```
 
-### Run a specific pi command
+### Start pi directly
 
 ```bash
-openshell sandbox create --from pi -- pi --version
-```
-
-## Provider Setup
-
-Use `/login` in interactive mode, or set an API-key environment variable before starting pi, for example:
-
-```bash
-export ANTHROPIC_API_KEY=sk-ant-...
-pi
+openshell sandbox create --from pi -- pi
 ```

--- a/sandboxes/pi/policy.yaml
+++ b/sandboxes/pi/policy.yaml
@@ -1,0 +1,191 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+version: 1
+
+# --- Sandbox setup configuration (queried once at startup) ---
+
+filesystem_policy:
+  include_workdir: true
+  read_only:
+    - /usr
+    - /lib
+    - /proc
+    - /dev/urandom
+    - /app
+    - /etc
+    - /var/log
+  read_write:
+    - /sandbox
+    - /tmp
+    - /dev/null
+
+landlock:
+  compatibility: best_effort
+
+process:
+  run_as_user: sandbox
+  run_as_group: sandbox
+
+# --- Network policies (queried per-CONNECT request) ---
+#
+# Each named policy maps a set of allowed (binary, endpoint) pairs.
+# Binary identity is resolved via /proc/net/tcp inode lookup + /proc/{pid}/exe.
+# Ancestors (/proc/{pid}/status PPid walk) and cmdline paths are also matched.
+# SHA256 integrity is enforced in Rust via trust-on-first-use, not here.
+
+network_policies:
+  pi:
+    name: pi
+    endpoints:
+      # API-key providers
+      - { host: api.anthropic.com, port: 443 }
+      - { host: api.openai.com, port: 443 }
+      - { host: api.deepseek.com, port: 443 }
+      - { host: generativelanguage.googleapis.com, port: 443 }
+      - { host: api.mistral.ai, port: 443 }
+      - { host: api.groq.com, port: 443 }
+      - { host: api.cerebras.ai, port: 443 }
+      - { host: api.x.ai, port: 443 }
+      - { host: openrouter.ai, port: 443 }
+      - { host: ai-gateway.vercel.sh, port: 443 }
+      - { host: router.huggingface.co, port: 443 }
+      - { host: api.fireworks.ai, port: 443 }
+      - { host: api.together.ai, port: 443 }
+      - { host: api.kimi.com, port: 443 }
+      - { host: api.moonshot.ai, port: 443 }
+      - { host: api.moonshot.cn, port: 443 }
+      - { host: api.minimax.io, port: 443 }
+      - { host: api.minimaxi.com, port: 443 }
+      - { host: api.xiaomimimo.com, port: 443 }
+      - { host: token-plan-cn.xiaomimimo.com, port: 443 }
+      - { host: token-plan-ams.xiaomimimo.com, port: 443 }
+      - { host: token-plan-sgp.xiaomimimo.com, port: 443 }
+      - { host: api.z.ai, port: 443 }
+      - { host: opencode.ai, port: 443 }
+      # Cloud providers
+      - { host: bedrock-runtime.us-east-1.amazonaws.com, port: 443 }
+      - { host: bedrock-runtime.eu-central-1.amazonaws.com, port: 443 }
+      - { host: api.cloudflare.com, port: 443 }
+      - { host: gateway.ai.cloudflare.com, port: 443 }
+      # Add region-specific Vertex AI hosts here if needed, e.g.:
+      # - { host: us-central1-aiplatform.googleapis.com, port: 443 }
+      # Subscription login / token refresh endpoints
+      - { host: claude.ai, port: 443 }
+      - { host: platform.claude.com, port: 443 }
+      - { host: auth.openai.com, port: 443 }
+      - { host: chatgpt.com, port: 443 }
+      - { host: github.com, port: 443 }
+      - { host: api.github.com, port: 443 }
+      # pi downloads managed fd/ripgrep binaries from GitHub release assets.
+      - { host: release-assets.githubusercontent.com, port: 443 }
+      - { host: api.githubcopilot.com, port: 443 }
+      - { host: api.individual.githubcopilot.com, port: 443 }
+      - { host: api.business.githubcopilot.com, port: 443 }
+      - { host: api.enterprise.githubcopilot.com, port: 443 }
+      - { host: copilot-proxy.githubusercontent.com, port: 443 }
+      - { host: default.exp-tas.com, port: 443 }
+    binaries:
+      - { path: /usr/bin/pi }
+      - { path: /usr/local/bin/pi }
+      - { path: /usr/lib/node_modules/@earendil-works/pi-coding-agent/dist/cli.js }
+      - { path: /usr/local/lib/node_modules/@earendil-works/pi-coding-agent/dist/cli.js }
+      - { path: /usr/bin/node }
+      - { path: /usr/local/bin/node }
+
+  github_ssh_over_https:
+    name: github-ssh-over-https
+    endpoints:
+      - host: github.com
+        port: 443
+        protocol: rest
+        tls: terminate
+        enforcement: enforce
+        rules:
+          # Git Smart HTTP read-only: allow clone, fetch, pull
+          # Discovery (query string is included in path matching)
+          - allow:
+              method: GET
+              path: "/**/info/refs*"
+          # Data transfer for reads (all repos)
+          - allow:
+              method: POST
+              path: "/**/git-upload-pack"
+          # Data transfer for writes
+          # - allow:
+          #    method: POST
+          #    path: "/**/git-receive-pack"
+    binaries:
+      - { path: /usr/bin/git }
+
+  nvidia_inference:
+    name: nvidia-inference
+    endpoints:
+      - { host: integrate.api.nvidia.com, port: 443 }
+    binaries:
+      - { path: /usr/bin/curl }
+      - { path: /bin/bash }
+
+  # --- GitHub REST API (read-only) ---
+  github_rest_api:
+    name: github-rest-api
+    endpoints:
+      - host: api.github.com
+        port: 443
+        protocol: rest
+        tls: terminate
+        enforcement: enforce
+        access: read-only
+    binaries:
+      - { path: /usr/bin/gh }
+
+  pypi:
+    name: pypi
+    endpoints:
+      - { host: pypi.org, port: 443 }
+      - { host: files.pythonhosted.org, port: 443 }
+      # uv python install downloads from python-build-standalone on GitHub
+      - { host: github.com, port: 443 }
+      - { host: objects.githubusercontent.com, port: 443 }
+      # uv resolves python-build-standalone release metadata via the GitHub API
+      - { host: api.github.com, port: 443 }
+      - { host: downloads.python.org, port: 443 }
+    binaries:
+      - { path: /sandbox/.venv/bin/python }
+      - { path: /sandbox/.venv/bin/python3 }
+      - { path: /sandbox/.venv/bin/pip }
+      - { path: /app/.venv/bin/python }
+      - { path: /app/.venv/bin/python3 }
+      - { path: /app/.venv/bin/pip }
+      - { path: /usr/local/bin/uv }
+      # Managed Python installations from uv python install
+      - { path: "/sandbox/.uv/python/**" }
+
+  vscode:
+    name: vscode
+    endpoints:
+      - { host: update.code.visualstudio.com, port: 443 }
+      # NOTE: OPA host matching uses exact equality, not glob — list hosts explicitly.
+      - { host: az764295.vo.msecnd.net, port: 443 }
+      - { host: vscode.download.prss.microsoft.com, port: 443 }
+      - { host: marketplace.visualstudio.com, port: 443 }
+      - { host: gallerycdn.vsassets.io, port: 443 }
+    binaries:
+      - { path: /usr/bin/curl }
+      - { path: /usr/bin/wget }
+      - { path: "/sandbox/.vscode-server/**" }
+      - { path: "/sandbox/.vscode-remote-containers/**" }
+
+  cursor:
+    name: cursor
+    endpoints:
+      - { host: cursor.blob.core.windows.net, port: 443 }
+      # NOTE: OPA host matching uses exact equality, not glob — list hosts explicitly.
+      - { host: api2.cursor.sh, port: 443 }
+      - { host: repo.cursor.sh, port: 443 }
+      - { host: download.cursor.sh, port: 443 }
+      - { host: cursor.download.prss.microsoft.com, port: 443 }
+    binaries:
+      - { path: /usr/bin/curl }
+      - { path: /usr/bin/wget }
+      - { path: "/sandbox/.cursor-server/**" }


### PR DESCRIPTION
Adds a new sandbox Docker image with [Pi](https://pi.dev/) installed. We don't pin the version in the npm install command, since there are new versions [very often](https://github.com/earendil-works/pi/releases). The network policy document is a trimmed version of the base policy and with additional GitHub release domains to allow Pi downloading binaries at startup (fd and ripgrep).

As an aside, I'm working on making it easier to authenticate headlessly in pi, such as authenticating a Codex subscription via a device code (which is what the Codex CLI does). This will make it smoother to set up providers in an OpenShell-sandboxed Pi. Feel free to follow along here: https://github.com/earendil-works/pi/issues/3424