### PR TITLE
Add data-eng sandbox image.

### DIFF
--- a/sandboxes/data-eng/Dockerfile
+++ b/sandboxes/data-eng/Dockerfile
@@ -1,0 +1,39 @@
+# syntax=docker/dockerfile:1.4
+
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Data engineering sandbox image for OpenShell
+#
+# Builds on the community base sandbox and adds Python 3.12 with DuckDB,
+# pandas, pyarrow, and httpx for local data processing workflows.
+# Build:  docker build -t openshell-data-eng --build-arg BASE_IMAGE=openshell-base .
+# Run:    openshell sandbox create --from data-eng
+
+ARG BASE_IMAGE=ghcr.io/nvidia/openshell-community/sandboxes/base:latest
+FROM ${BASE_IMAGE}
+
+USER root
+
+# Install Python 3.12 via uv (base provides uv; 3.13 is already present)
+RUN uv python install 3.12 && uv cache clean
+
+# Re-create the sandbox venv with Python 3.12 and install data-engineering packages
+RUN uv venv --python 3.12 --seed /sandbox/.venv && \
+    uv pip install --python /sandbox/.venv/bin/python \
+        cloudpickle \
+        duckdb \
+        pandas \
+        pyarrow \
+        httpx \
+    && uv cache clean && \
+    chown -R sandbox:sandbox /sandbox/.venv
+
+# Copy entrypoint
+COPY entrypoint.sh /usr/local/bin/entrypoint
+RUN chmod +x /usr/local/bin/entrypoint
+
+USER sandbox
+
+ENTRYPOINT ["/usr/local/bin/entrypoint"]
+CMD ["/bin/bash", "-l"]

--- a/sandboxes/data-eng/README.md
+++ b/sandboxes/data-eng/README.md
@@ -1,0 +1,49 @@
+# Data Engineering Sandbox
+
+OpenShell sandbox image pre-configured with Python 3.12 and popular data engineering libraries for local data processing, transformation, and analysis.
+
+## What's Included
+
+- **Python 3.12** — Pinned runtime for stable data engineering workflows
+- **DuckDB** — Fast in-process analytical SQL engine; query CSV, Parquet, JSON, and more directly from Python or SQL
+- **pandas** — DataFrame library for data manipulation and analysis
+- **pyarrow** — Apache Arrow columnar format; Parquet read/write and zero-copy data interchange
+- **httpx** — Async-capable HTTP client for fetching remote datasets and APIs
+- Everything from the [base sandbox](../base/README.md)
+
+## Build
+
+```bash
+docker build -t openshell-data-eng .
+```
+
+To build against a specific base image:
+
+```bash
+docker build -t openshell-data-eng --build-arg BASE_IMAGE=ghcr.io/nvidia/openshell-community/sandboxes/base:latest .
+```
+
+## Usage
+
+### Create a sandbox
+
+```bash
+openshell sandbox create --from data-eng
+```
+
+### Quick start
+
+All data tools are available from the pre-configured venv:
+
+```python
+import duckdb
+import pandas as pd
+import pyarrow as pa
+import httpx
+
+# Query a local Parquet file with DuckDB
+df = duckdb.sql("SELECT * FROM 'data.parquet' LIMIT 10").df()
+
+# Fetch a remote CSV and load into pandas
+response = httpx.get("https://example.com/data.csv")
+```

--- a/sandboxes/data-eng/entrypoint.sh
+++ b/sandboxes/data-eng/entrypoint.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Entrypoint for data-eng sandbox — prints installed tool versions on start
+set -euo pipefail
+
+echo "[data-eng] Installed tool versions:"
+echo "  python:  $(python --version 2>&1)"
+echo "  duckdb:  $(python -c 'import duckdb; print(duckdb.__version__)')"
+echo "  pandas:  $(python -c 'import pandas; print(pandas.__version__)')"
+echo "  pyarrow: $(python -c 'import pyarrow; print(pyarrow.__version__)')"
+echo "  httpx:   $(python -c 'import httpx; print(httpx.__version__)')"
+echo ""
+echo "========================================"
+echo "Data engineering sandbox ready!"
+echo "========================================"
+echo ""
+
+if [ $# -eq 0 ]; then
+    exec /bin/bash -l
+else
+    exec "$@"
+fi


### PR DESCRIPTION
## What this adds

A data engineering sandbox pre-configured for agents doing local data 
processing, transformation, and analysis workflows.

## Pre-installed tools

- Python 3.12 — pinned runtime for stable data engineering workflows
- DuckDB — fast in-process analytical SQL engine
- pandas — DataFrame library for data manipulation and analysis
- pyarrow — Apache Arrow columnar format, Parquet read/write
- httpx — async-capable HTTP client for fetching remote datasets

## Usage

openshell sandbox create --from data-eng

## Testing

Built and verified locally. All packages install cleanly from the 
base image. Entrypoint prints installed versions on sandbox start.