### PR TITLE
chore(base): upgrade sandbox Python to 3.14

### DIFF
--- a/sandboxes/base/Dockerfile
+++ b/sandboxes/base/Dockerfile
@@ -96,9 +96,9 @@ RUN curl -fsSL https://claude.ai/install.sh | bash \
 # uv manages the Python toolchain; no system Python packages are needed.
 COPY --from=ghcr.io/astral-sh/uv:0.10.8 /uv /usr/local/bin/uv
 ENV UV_PYTHON_INSTALL_DIR="/sandbox/.uv/python"
-RUN uv python install 3.13 && \
-    ln -s $(uv python find 3.13) /usr/local/bin/python3 && \
-    ln -s $(uv python find 3.13) /usr/local/bin/python && \
+RUN uv python install 3.14.3 && \
+    ln -s $(uv python find 3.14.3) /usr/local/bin/python3 && \
+    ln -s $(uv python find 3.14.3) /usr/local/bin/python && \
     uv cache clean
 
 # Final base image
@@ -122,10 +122,10 @@ COPY skills/ /sandbox/.agents/skills/
 
 # Set up sandbox user home directory
 RUN mkdir -p /sandbox/.claude/skills && \
-    # Create a writable venv using uv-managed Python 3.13.
+    # Create a writable venv using uv-managed Python 3.14.3.
     # Sandbox users can `uv pip install` (or `pip install`) into
     # this venv without touching the base image layer.
-    uv venv --python 3.13 --seed /sandbox/.venv && \
+    uv venv --python 3.14.3 --seed /sandbox/.venv && \
     uv pip install --python /sandbox/.venv/bin/python cloudpickle && \
     uv cache clean && \
     chown -R sandbox:sandbox /sandbox/.venv && \

--- a/sandboxes/base/README.md
+++ b/sandboxes/base/README.md
@@ -7,7 +7,7 @@ The foundational sandbox image that all other OpenShell Community sandbox images
 | Category | Tools |
 |----------|-------|
 | OS | Ubuntu 24.04 |
-| Languages | `python3` (3.13), `node` (22.22.1) |
+| Languages | `python3` (3.14.3), `node` (22.22.1) |
 | Package managers | `npm` (11.11.0), `uv` (0.10.8), `pip` |
 | Coding agents | `claude`, `opencode`, `codex`, `copilot` |
 | Developer | `gh`, `git`, `vim`, `nano` |


### PR DESCRIPTION
## Summary
Upgrade the community base sandbox container from uv-managed Python 3.13 to Python 3.14.3 so Python callables serialized by OpenShell 3.14 test runners can execute inside the sandbox without bytecode opcode mismatches.

## Changes
- Install uv-managed CPython 3.14.3 in `sandboxes/base/Dockerfile`.
- Create the default writable `/sandbox/.venv` with Python 3.14.3.
- Update the base sandbox README language table.

## Testing
- [x] `uv run python scripts/check_license_headers.py --check`
- [x] `git diff --check`
- [x] `uv python list 3.14.3 --only-downloads --all-platforms --all-arches --show-urls`
- [ ] `docker buildx build --load -t openshell-community-base:python-3.14.3 sandboxes/base` (not run: no local Docker daemon reachable)

## Checklist
- [x] Commit is signed off for DCO
