### PR TITLE
Add brikie sandbox image

### DIFF
--- a/sandboxes/brikie/Dockerfile
+++ b/sandboxes/brikie/Dockerfile
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1.4
+
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 brikie contributors. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# brikie sandbox image for OpenShell
+#
+# Builds on the community base sandbox and adds brikie — a modular agent
+# harness where every capability is an optional, hot-swappable Brick.
+# Build:  docker build -t openshell-brikie --build-arg BASE_IMAGE=openshell-base .
+# Run:    openshell sandbox create --from brikie
+
+ARG BASE_IMAGE=ghcr.io/nvidia/openshell-community/sandboxes/base:latest
+FROM ${BASE_IMAGE}
+
+USER root
+
+# Install brikie from PyPI.
+RUN pip install --no-cache-dir --break-system-packages brikie
+
+# Copy sandbox policy
+COPY policy.yaml /etc/openshell/policy.yaml
+
+USER sandbox
+
+ENTRYPOINT ["brikie"]

--- a/sandboxes/brikie/README.md
+++ b/sandboxes/brikie/README.md
@@ -1,0 +1,70 @@
+# brikie Sandbox
+
+OpenShell sandbox image pre-configured with
+[brikie](https://github.com/VeelaCleave/brikie) — a modular agent
+harness where every capability is an optional, hot-swappable Brick.
+
+## What's Included
+
+- **brikie** (from PyPI)
+- Everything from the [base sandbox](../base/README.md)
+
+## Build
+
+```bash
+docker build -t openshell-brikie .
+```
+
+To build against a specific base image:
+
+```bash
+docker build -t openshell-brikie --build-arg BASE_IMAGE=ghcr.io/nvidia/openshell-community/sandboxes/base:latest .
+```
+
+## Usage
+
+### Create a sandbox
+
+```bash
+openshell sandbox create --from brikie
+```
+
+### Pick your provider
+
+brikie reads provider credentials from the environment, so OpenShell's
+managed inference works out of the box. Choose a provider preset at
+launch:
+
+```bash
+openshell sandbox create --from brikie -- --preset anthropic   # ANTHROPIC_API_KEY
+openshell sandbox create --from brikie -- --preset openai      # OPENAI_API_KEY
+openshell sandbox create --from brikie -- --preset openrouter  # OPENROUTER_API_KEY
+openshell sandbox create --from brikie -- --preset groq        # GROQ_API_KEY
+```
+
+brikie also honors `ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL`, so
+`openshell inference set` rerouting applies with no extra configuration.
+
+### Choose your bricks
+
+By default brikie boots a full stack (file tools, memory, logging,
+security, and the AFK orchestration souls). To run a leaner set:
+
+```bash
+openshell sandbox create --from brikie -- --set minimal --preset anthropic
+```
+
+Compose a custom Build Set at [brikie.co](https://brikie.co).
+
+## Network Policy
+
+The bundled `policy.yaml` allows brikie to reach:
+
+- model provider APIs (Anthropic, OpenAI, OpenRouter, Groq, DeepSeek,
+  Mistral, Cerebras, xAI, Together, Fireworks, Hugging Face, Vercel AI
+  Gateway, Google, and NVIDIA-hosted inference)
+- the brikie.co brick registry (search / install / publish)
+- the GitHub REST API, read-only (the optional issue-reading brick)
+- PyPI (installing additional bricks at runtime)
+
+Everything else is denied by default.

--- a/sandboxes/brikie/policy.yaml
+++ b/sandboxes/brikie/policy.yaml
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 brikie contributors. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+version: 1
+
+# --- Sandbox setup configuration (queried once at startup) ---
+
+filesystem_policy:
+  include_workdir: true
+  read_only:
+    - /usr
+    - /lib
+    - /proc
+    - /dev/urandom
+    - /app
+    - /etc
+    - /var/log
+  read_write:
+    - /sandbox
+    - /tmp
+    - /dev/null
+
+landlock:
+  compatibility: best_effort
+
+process:
+  run_as_user: sandbox
+  run_as_group: sandbox
+
+# --- Network policies (queried per-CONNECT request) ---
+
+network_policies:
+  brikie:
+    name: brikie
+    endpoints:
+      # API-key model providers. brikie's HTTPProvider speaks both the
+      # OpenAI and Anthropic wire formats, so any OpenAI-compatible host
+      # works once allowed here.
+      - { host: api.anthropic.com, port: 443 }
+      - { host: api.openai.com, port: 443 }
+      - { host: openrouter.ai, port: 443 }
+      - { host: api.groq.com, port: 443 }
+      - { host: api.deepseek.com, port: 443 }
+      - { host: api.mistral.ai, port: 443 }
+      - { host: api.cerebras.ai, port: 443 }
+      - { host: api.x.ai, port: 443 }
+      - { host: api.together.ai, port: 443 }
+      - { host: api.fireworks.ai, port: 443 }
+      - { host: router.huggingface.co, port: 443 }
+      - { host: ai-gateway.vercel.sh, port: 443 }
+      - { host: generativelanguage.googleapis.com, port: 443 }
+      # NVIDIA-hosted inference
+      - { host: integrate.api.nvidia.com, port: 443 }
+      # The brikie.co brick registry: search / install / publish bricks
+      - { host: brikie.co, port: 443 }
+    binaries:
+      - { path: /usr/local/bin/brikie }
+      - { path: /usr/bin/brikie }
+      - { path: /usr/local/bin/python }
+      - { path: /usr/local/bin/python3 }
+      - { path: /usr/bin/python3 }
+
+  # --- GitHub REST API (read-only) ---
+  # brikie's optional GitHub brick (BRK-430) reads repository issues to
+  # feed the Dreamer triaged community requests.
+  github_rest_api:
+    name: github-rest-api
+    endpoints:
+      - host: api.github.com
+        port: 443
+        protocol: rest
+        tls: terminate
+        enforcement: enforce
+        access: read-only
+    binaries:
+      - { path: /usr/local/bin/python }
+      - { path: /usr/local/bin/python3 }
+      - { path: /usr/bin/python3 }
+
+  pypi:
+    name: pypi
+    endpoints:
+      - { host: pypi.org, port: 443 }
+      - { host: files.pythonhosted.org, port: 443 }
+    binaries:
+      - { path: /usr/local/bin/pip }
+      - { path: /usr/local/bin/python }
+      - { path: /usr/local/bin/python3 }
+      - { path: /usr/bin/python3 }


### PR DESCRIPTION
## What

Adds a `brikie` sandbox to the community catalog under `sandboxes/brikie/`.

[brikie](https://github.com/VeelaCleave/brikie) is a modular agent harness where every capability is an optional, hot-swappable Brick — users compose an agent (interface + provider + tools/memory/security/orchestration) from a brick catalog. It's on PyPI (`pip install brikie`) and has a public brick registry at [brikie.co](https://brikie.co).

## Why it fits OpenShell

- **Credentials via env vars.** brikie's provider presets reference keys as `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `OPENROUTER_API_KEY` / `GROQ_API_KEY`, so OpenShell's provider injection works unmodified.
- **Inference rerouting.** brikie honors `ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL` at startup, so `openshell inference set` routing applies with no brikie configuration.
- **No-wizard boot.** `--preset <provider>` configures everything from the environment — nothing interactive, nothing written outside the sandbox.

## Files

- `sandboxes/brikie/Dockerfile` — builds on the community base, installs brikie from PyPI
- `sandboxes/brikie/policy.yaml` — filesystem + network allowlist (model-provider APIs, brikie.co registry, GitHub REST read-only, PyPI)
- `sandboxes/brikie/README.md` — purpose, build, and usage

## Testing

Built locally against the base image; brikie launches as the `sandbox` user and `policy.yaml` lands at `/etc/openshell/policy.yaml`. Usage:

```bash
openshell sandbox create --from brikie -- --preset anthropic
```

Commit is DCO signed-off.