### PR TITLE
feat(base): install Goose CLI

### DIFF
--- a/sandboxes/base/Dockerfile
+++ b/sandboxes/base/Dockerfile
@@ -26,6 +26,7 @@ WORKDIR /sandbox
 # dnsutils: dig, nslookup
 # Python is managed entirely by uv (see devtools stage).
 RUN apt-get update && apt-get install -y --no-install-recommends \
+        bash \
         ca-certificates \
         curl \
         dnsutils \
@@ -91,6 +92,23 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
 RUN curl -fsSL https://claude.ai/install.sh | bash \
     && cp /root/.local/bin/claude /usr/local/bin/claude \
     && chmod 755 /usr/local/bin/claude
+
+# Install Goose CLI/agent for all OpenShell sandboxes.
+# Goose provider credentials are intentionally configured at runtime, not baked into the image.
+ARG GOOSE_VERSION=stable
+RUN curl -fsSL "https://github.com/aaif-goose/goose/releases/download/${GOOSE_VERSION}/download_cli.sh" \
+        -o /tmp/download_cli.sh \
+    && if [ "${GOOSE_VERSION}" = "stable" ]; then \
+         CONFIGURE=false env -u GOOSE_VERSION bash /tmp/download_cli.sh; \
+       else \
+         CONFIGURE=false bash /tmp/download_cli.sh; \
+       fi \
+    && rm -f /tmp/download_cli.sh \
+    && if [ -f "$HOME/.local/bin/goose" ]; then \
+         mv "$HOME/.local/bin/goose" /usr/local/bin/goose; \
+       fi \
+    && chmod +x /usr/local/bin/goose \
+    && goose --version
 
 # uv (Python package/project manager) — pinned for reproducibility.
 # uv manages the Python toolchain; no system Python packages are needed.

--- a/sandboxes/base/README.md
+++ b/sandboxes/base/README.md
@@ -9,7 +9,7 @@ The foundational sandbox image that all other OpenShell Community sandbox images
 | OS | Ubuntu 24.04 |
 | Languages | `python3` (3.14.3), `node` (22.22.1) |
 | Package managers | `npm` (11.11.0), `uv` (0.10.8), `pip` |
-| Coding agents | `claude`, `opencode`, `codex`, `copilot` |
+| Coding agents | `claude`, `goose`, `opencode`, `codex`, `copilot` |
 | Developer | `gh`, `git`, `vim`, `nano` |
 | Networking | `ping`, `dig`, `nslookup`, `nc`, `traceroute`, `netstat`, `curl` |
 
@@ -56,6 +56,15 @@ FROM ${BASE_IMAGE}
 ```
 
 See the other directories under `sandboxes/` for examples.
+
+## Goose
+
+The base image installs Goose from the official AAIF Goose repository:
+
+- https://github.com/aaif-goose/goose
+- https://goose-docs.ai/
+
+Goose provider credentials are configured at runtime and are not baked into the sandbox image.
 
 ## Codex authentication
 


### PR DESCRIPTION
## Summary
- install the Goose CLI in the base sandbox image from the official AAIF Goose repository
- keep Goose provider credentials configured at runtime, not baked into the image
- document Goose in the base sandbox README

## Verification
- `podman build -t openshell-base-goose-test sandboxes/base`
- `podman run --rm openshell-base-goose-test -lc 'which goose && goose --version'` -> `/usr/local/bin/goose`, `1.37.0`
- `curl -I https://github.com/aaif-goose/goose/releases/download/stable/download_cli.sh` -> `HTTP/2 302`
- `grep -R "github.com/block/goose" -n . || true` -> no matches
- `grep -R "block/goose" -n . || true` -> no matches
- `grep -R "github.com/block" -n . || true` -> no matches
- `podman run --rm openshell-base-goose-test -lc 'env | grep -Ei "GOOSE|OPENAI|ANTHROPIC|API_KEY" || true'` -> no output
