### PR TITLE
feat(sandbox): add Goose agent community image

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This repo is the community ecosystem around OpenShell -- a hub for contributed s
 | `sandboxes/base/`       | Foundational image with system tools, users, and dev environment |
 | `sandboxes/droid/`      | Android automation and mobile testing workflows              |
 | `sandboxes/gemini/`     | Gemini CLI workflows                                         |
+| `sandboxes/goose/`      | [Goose](https://github.com/aaif-goose/goose) AI agent CLI pre-installed |
 | `sandboxes/nvidia-gpu/` | GPU-enabled VM sandbox image with NVIDIA userspace tooling   |
 | `sandboxes/ollama/`     | Ollama for local and cloud LLMs with Claude Code, Codex, OpenCode pre-installed |
 | `sandboxes/pi/`         | [Pi](https://pi.dev) pre-installed                           |

--- a/sandboxes/goose/.goosehints
+++ b/sandboxes/goose/.goosehints
@@ -1,0 +1,26 @@
+Goose is running inside of an OpenShell sandbox — Goose CLI in a shell
+session, not Goose Desktop. Expect text and tool output only; MCP Apps will
+not render interactive UI here.
+
+## Required at session start (before your first reply)
+
+1. Load the épinettes skill — this environment is not a normal dev machine:
+   `load_skill(name: "epinettes")`
+   Do not skip this. Do not guess at policy, paths, or network rules.
+2. If /AGENTS.md exists at the filesystem root, read it after loading épinettes.
+   An existing AGENTS.md may predate or replace OpenShell's. Mechanistic denial
+   drafts may still appear for the operator to approve.
+3. Before any GitHub work (issues, PRs, `gh`, git push to github.com), also load:
+   `load_skill(name: "github")`
+
+Fallback if load_skill fails — read the files directly:
+
+- /sandbox/.agents/skills/epinettes/SKILL.md
+- /sandbox/.agents/skills/github/SKILL.md
+
+OpenShell supervisor skills live under /etc/openshell/skills/ — not on Goose's
+discovery path. Read them when /AGENTS.md, a denial, or the task points you
+there. Policy Advisor (agent_policy_proposals_enabled) may or may not be on.
+
+Goose config: /sandbox/.config/goose/config.yaml — goose configure, then
+goose session.

--- a/sandboxes/goose/Dockerfile
+++ b/sandboxes/goose/Dockerfile
@@ -1,0 +1,48 @@
+# syntax=docker/dockerfile:1.4
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 canardleteer
+# SPDX-License-Identifier: Apache-2.0
+
+# Goose AI agent sandbox image for OpenShell
+#
+# Builds on the community base sandbox and adds the Goose CLI.
+# Build:  docker build -t openshell-goose --build-arg BASE_IMAGE=openshell-base .
+# Run:    openshell sandbox create --from goose
+
+ARG BASE_IMAGE=ghcr.io/nvidia/openshell-community/sandboxes/base:latest
+FROM ${BASE_IMAGE}
+
+USER root
+
+# Install Goose CLI. Default tracks AAIF stable; pin with --build-arg GOOSE_VERSION=v1.39.0
+ARG GOOSE_VERSION=stable
+RUN curl -fsSL "https://github.com/aaif-goose/goose/releases/download/${GOOSE_VERSION}/download_cli.sh" \
+        -o /tmp/download_cli.sh \
+    && if [ "${GOOSE_VERSION}" = "stable" ]; then \
+         CONFIGURE=false GOOSE_BIN_DIR=/usr/local/bin env -u GOOSE_VERSION bash /tmp/download_cli.sh; \
+       else \
+         CONFIGURE=false GOOSE_BIN_DIR=/usr/local/bin GOOSE_VERSION="${GOOSE_VERSION}" bash /tmp/download_cli.sh; \
+       fi \
+    && rm -f /tmp/download_cli.sh \
+    && if [ -f /root/.local/bin/goose ]; then \
+         mv /root/.local/bin/goose /usr/local/bin/goose; \
+       fi \
+    && chmod +x /usr/local/bin/goose \
+    && goose --version
+
+# Copy sandbox policy, Goose skills, and global hints (~/.config/goose/.goosehints)
+COPY policy.yaml /etc/openshell/policy.yaml
+COPY skills/ /tmp/goose-skills/
+COPY .goosehints /sandbox/.config/goose/.goosehints
+COPY config.yaml /sandbox/.config/goose/config.yaml
+
+# Create Goose config directories and install goose-specific skills
+RUN mkdir -p /sandbox/.config/goose /sandbox/.local/share/goose && \
+    cp -r /tmp/goose-skills/* /sandbox/.agents/skills/ && \
+    rm -rf /tmp/goose-skills && \
+    chown -R sandbox:sandbox /sandbox/.config /sandbox/.local \
+        /sandbox/.agents/skills/epinettes
+
+USER sandbox
+
+ENTRYPOINT ["/bin/bash"]

--- a/sandboxes/goose/README.md
+++ b/sandboxes/goose/README.md
@@ -1,0 +1,185 @@
+# Goose Sandbox
+
+OpenShell sandbox image pre-configured with
+[Goose](https://github.com/aaif-goose/goose) — an open source, extensible AI
+agent for code, workflows, and automation.
+
+## What's Included
+
+- **Goose CLI** — from [AAIF Goose](https://github.com/aaif-goose/goose);
+  **`stable` by default**, overridable at build time (see below)
+- **`.goosehints`** — Goose
+  [global hints file](https://goose-docs.ai/docs/guides/context-engineering/using-goosehints/)
+  at `/sandbox/.config/goose/.goosehints`
+- **`épinettes` skill** — filesystem, network policy, dependencies, and
+  blocked-access workflow for Goose in OpenShell
+  (`/sandbox/.agents/skills/epinettes/`)
+- **Goose network policy** — LLM provider endpoints, GitHub, PyPI, npm, and a
+  starter **`goose_mcp`** block for remote MCP extensions
+- **Default `config.yaml`** — telemetry disabled only
+  (`GOOSE_TELEMETRY_ENABLED: false`); provider and extensions are yours at
+  runtime
+- Everything from the [base sandbox](../base/README.md)
+
+## Configuration
+
+The image bakes a **minimal** `/sandbox/.config/goose/config.yaml` —
+telemetry off, nothing else. Provider credentials, models, and extensions are
+**runtime config** (12-factor): add them when you create or use the sandbox,
+not in the image.
+
+### Option 1: Configure inside the sandbox
+
+```bash
+openshell sandbox create --from goose
+goose configure    # provider, extensions, etc. — merges into config.yaml
+goose session
+```
+
+### Option 2: Upload your own config at create time
+
+`--upload` **replaces** the baked file. Include provider settings **and** keep
+telemetry off if you want the same default:
+
+```bash
+openshell sandbox create \
+  --from openshell-goose:latest \
+  --upload /path/to/goose-config.yaml:/sandbox/.config/goose/config.yaml \
+  -- goose session
+```
+
+Example `goose-config.yaml`:
+
+```yaml
+GOOSE_TELEMETRY_ENABLED: false
+active_provider: ollama
+GOOSE_PROVIDER: ollama
+GOOSE_MODEL: your-model
+OLLAMA_HOST: https://your-ollama-host
+providers:
+  ollama:
+    enabled: true
+    model: your-model
+    configured: true
+```
+
+### Option 3: Edit after connect
+
+```bash
+openshell sandbox connect my-goose
+# edit /sandbox/.config/goose/config.yaml, then:
+goose session
+```
+
+Goose also accepts `GOOSE_TELEMETRY_OFF=1` via `--env` on sandbox create as an
+override; the baked config already disables telemetry unless you change it in
+`goose configure`.
+
+## Build
+
+```bash
+docker build -t openshell-goose .
+```
+
+Pin a specific Goose release:
+
+```bash
+docker build -t openshell-goose --build-arg GOOSE_VERSION=v1.39.0 .
+```
+
+To build against a specific base image:
+
+```bash
+docker build -t openshell-goose \
+  --build-arg \
+  BASE_IMAGE=ghcr.io/nvidia/openshell-community/sandboxes/base:latest \
+  .
+```
+
+## Usage
+
+### Create a sandbox
+
+```bash
+openshell sandbox create --from goose
+```
+
+See [Configuration](#configuration) for provider setup.
+
+## MCP extensions
+
+Goose connects to tools through
+[MCP extensions](https://goose-docs.ai/docs/getting-started/using-extensions).
+This image ships policy for outbound LLM traffic (`goose:`) and a separate
+**`goose_mcp`** block for MCP Streamable HTTP extensions.
+
+### OpenShell MCP policy
+
+Remote MCP extensions need OpenShell **MCP policy support** (`protocol: mcp` in
+`policy.yaml`):
+
+- OpenShell host **≥ 0.0.72** (MCP policy support)
+
+The baked-in `goose_mcp` policy allows Goose (`/usr/local/bin/goose`) to reach
+pre-listed MCP servers with method/tool inspection. Add new hosts to
+`sandboxes/goose/policy.yaml` (or pass a custom policy at sandbox create time)
+before enabling additional extensions.
+
+### Excalidraw MCP App (remote)
+
+[Excalidraw MCP App](https://goose-docs.ai/extensions/detail?id=excalidraw-mcp-app)
+is a hosted Streamable HTTP extension — no local install. It is pre-allowed in
+`goose_mcp` at `excalidraw-mcp-app.vercel.app/mcp`.
+
+```bash
+openshell sandbox create \
+  --from openshell-goose:latest \
+  -- goose session --debug \
+    --with-streamable-http-extension "https://excalidraw-mcp-app.vercel.app/mcp"
+```
+
+Example prompt:
+
+```text
+Use Excalidraw to draw a simple two-box flowchart: Start → Done. Save the
+output as /sandbox/output.excalidraw.
+```
+
+OpenShell runs Goose in a terminal — you will see tool traces and text
+summaries, not a rendered diagram. Use `--debug` for full tool responses. To
+keep output, ask Goose to export scene data to a file under `/sandbox/`.
+
+**Persistent config** — add to `/sandbox/.config/goose/config.yaml`:
+
+```yaml
+extensions:
+  excalidraw:
+    name: Excalidraw
+    enabled: true
+    type: streamable_http
+    url: https://excalidraw-mcp-app.vercel.app/mcp
+    timeout: 300
+```
+
+### Adding another remote MCP extension
+
+1. Add a `protocol: mcp` endpoint under `goose_mcp` in `policy.yaml` (host,
+   port, `path`, and method/tool rules — see
+   [OpenShell policy docs](https://docs.nvidia.com/openshell/latest/sandboxes/policies.html)).
+2. Enable the extension in Goose (`goose configure`, `config.yaml`, or
+   `--with-streamable-http-extension`).
+3. Rebuild the image or pass an updated policy file at sandbox create time.
+
+## Policy and skills
+
+| Resource | Path |
+|----------|------|
+| Image policy | `/etc/openshell/policy.yaml` |
+| Goose hints | `/sandbox/.config/goose/.goosehints` |
+| Épinettes skill | `/sandbox/.agents/skills/epinettes/SKILL.md` |
+| GitHub skill (base) | `/sandbox/.agents/skills/github/SKILL.md` |
+| OpenShell supervisor skills | `/etc/openshell/skills/` |
+
+When network access is denied, OpenShell may auto-draft rules for the operator
+to approve. Agent-driven proposals require `agent_policy_proposals_enabled`
+on the gateway or sandbox.

--- a/sandboxes/goose/config.yaml
+++ b/sandboxes/goose/config.yaml
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 canardleteer
+# SPDX-License-Identifier: Apache-2.0
+
+# Baked defaults for the goose sandbox image. Provider and extensions belong
+# in runtime config — see sandboxes/goose/README.md.
+GOOSE_TELEMETRY_ENABLED: false

--- a/sandboxes/goose/policy.yaml
+++ b/sandboxes/goose/policy.yaml
@@ -1,0 +1,185 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 canardleteer
+# SPDX-License-Identifier: Apache-2.0
+
+version: 1
+
+# --- Sandbox setup configuration (queried once at startup) ---
+
+filesystem_policy:
+  include_workdir: true
+  read_only:
+    - /usr
+    - /lib
+    - /proc
+    - /dev/urandom
+    - /app
+    - /etc
+    - /var/log
+  read_write:
+    - /sandbox
+    - /tmp
+    - /dev/null
+
+landlock:
+  compatibility: best_effort
+
+process:
+  run_as_user: sandbox
+  run_as_group: sandbox
+
+# --- Network policies (queried per-CONNECT request) ---
+#
+# Replaces the base image policy. Omits network policies for other bundled
+# agents (claude, copilot, codex, opencode, vscode, cursor). Shared dev
+# tooling (git, gh, pypi, npm) is kept below.
+#
+# Each named policy maps a set of allowed (binary, endpoint) pairs.
+# Binary identity is resolved via /proc/net/tcp inode lookup + /proc/{pid}/exe.
+# Ancestors (/proc/{pid}/status PPid walk) and cmdline paths are also matched.
+# SHA256 integrity is enforced in Rust via trust-on-first-use, not here.
+
+network_policies:
+  # --- Goose inference providers ---
+  # Trim endpoints to the LLM backends you use; the list is intentionally
+  # broad for a smoother first-run experience with goose configure.
+  goose:
+    name: goose
+    endpoints:
+      # API-key providers
+      - { host: api.anthropic.com, port: 443 }
+      - { host: api.openai.com, port: 443 }
+      - { host: api.deepseek.com, port: 443 }
+      - { host: generativelanguage.googleapis.com, port: 443 }
+      - { host: api.mistral.ai, port: 443 }
+      - { host: api.groq.com, port: 443 }
+      - { host: api.cerebras.ai, port: 443 }
+      - { host: api.x.ai, port: 443 }
+      - { host: openrouter.ai, port: 443 }
+      - { host: ai-gateway.vercel.sh, port: 443 }
+      - { host: router.huggingface.co, port: 443 }
+      - { host: api.fireworks.ai, port: 443 }
+      - { host: api.together.ai, port: 443 }
+      - { host: api.kimi.com, port: 443 }
+      - { host: api.moonshot.ai, port: 443 }
+      - { host: api.moonshot.cn, port: 443 }
+      - { host: api.minimax.io, port: 443 }
+      - { host: api.minimaxi.com, port: 443 }
+      - { host: api.xiaomimimo.com, port: 443 }
+      - { host: token-plan-cn.xiaomimimo.com, port: 443 }
+      - { host: token-plan-ams.xiaomimimo.com, port: 443 }
+      - { host: token-plan-sgp.xiaomimimo.com, port: 443 }
+      - { host: api.z.ai, port: 443 }
+      - { host: integrate.api.nvidia.com, port: 443 }
+      - { host: api.perplexity.ai, port: 443 }
+      - { host: api.novita.ai, port: 443 }
+      - { host: api.empiriolabs.ai, port: 443 }
+      - { host: cloud.near.ai, port: 443 }
+      - { host: api.routstr.com, port: 443 }
+      - { host: api.venice.ai, port: 443 }
+      - { host: api.scaleway.ai, port: 443 }
+      - { host: api.ovhcloud.com, port: 443 }
+      - { host: router.tetrate.ai, port: 443 }
+      # Cloud providers
+      - { host: bedrock-runtime.us-east-1.amazonaws.com, port: 443 }
+      - { host: bedrock-runtime.eu-central-1.amazonaws.com, port: 443 }
+      - { host: api.cloudflare.com, port: 443 }
+      - { host: gateway.ai.cloudflare.com, port: 443 }
+      - { host: "*-aiplatform.googleapis.com", port: 443 }
+      - { host: accounts.google.com, port: 443 }
+      - { host: oauth2.googleapis.com, port: 443 }
+      - { host: www.googleapis.com, port: 443 }
+      - { host: iamcredentials.googleapis.com, port: 443 }
+      # Ollama Cloud
+      - { host: ollama.com, port: 443 }
+      # Optional telemetry (opt-in)
+      - { host: us.i.posthog.com, port: 443 }
+    binaries:
+      - { path: /usr/local/bin/goose }
+      - { path: /usr/bin/goose }
+
+  # --- Goose remote MCP extensions (OpenShell ≥ 0.0.72) ---
+  # Trim host, path, and method rules to the extensions you enable. Broad
+  # allow here for a smoother first-run (Excalidraw MCP App).
+  goose_mcp:
+    name: goose-mcp
+    endpoints:
+      - host: excalidraw-mcp-app.vercel.app
+        port: 443
+        path: /mcp
+        protocol: mcp
+        tls: terminate
+        enforcement: enforce
+        mcp:
+          allow_all_known_mcp_methods: true
+    binaries:
+      - { path: /usr/local/bin/goose }
+      - { path: /usr/bin/goose }
+
+  github_ssh_over_https:
+    name: github-ssh-over-https
+    endpoints:
+      - host: github.com
+        port: 443
+        protocol: rest
+        tls: terminate
+        enforcement: enforce
+        rules:
+          # Git Smart HTTP read-only: allow clone, fetch, pull
+          # Discovery (query string is included in path matching)
+          - allow:
+              method: GET
+              path: "/**/info/refs*"
+          # Data transfer for reads (all repos)
+          - allow:
+              method: POST
+              path: "/**/git-upload-pack"
+          # Data transfer for writes
+          # - allow:
+          #    method: POST
+          #    path: "/**/git-receive-pack"
+    binaries:
+      - { path: /usr/bin/git }
+
+  # --- GitHub REST API (read-only) ---
+  github_rest_api:
+    name: github-rest-api
+    endpoints:
+      - host: api.github.com
+        port: 443
+        protocol: rest
+        tls: terminate
+        enforcement: enforce
+        access: read-only
+    binaries:
+      - { path: /usr/bin/gh }
+
+  # --- npm registry (MCP server installs) ---
+  npm:
+    name: npm
+    endpoints:
+      - { host: registry.npmjs.org, port: 443 }
+    binaries:
+      - { path: /usr/bin/node }
+      - { path: /usr/local/bin/npm }
+
+  pypi:
+    name: pypi
+    endpoints:
+      - { host: pypi.org, port: 443 }
+      - { host: files.pythonhosted.org, port: 443 }
+      # uv python install downloads from python-build-standalone on GitHub
+      - { host: github.com, port: 443 }
+      - { host: objects.githubusercontent.com, port: 443 }
+      # uv resolves python-build-standalone release metadata via the GitHub API
+      - { host: api.github.com, port: 443 }
+      - { host: downloads.python.org, port: 443 }
+    binaries:
+      - { path: /sandbox/.venv/bin/python }
+      - { path: /sandbox/.venv/bin/python3 }
+      - { path: /sandbox/.venv/bin/pip }
+      - { path: /app/.venv/bin/python }
+      - { path: /app/.venv/bin/python3 }
+      - { path: /app/.venv/bin/pip }
+      - { path: /usr/local/bin/uv }
+      # Managed Python installations from uv python install
+      - { path: "/sandbox/.uv/python/**" }

--- a/sandboxes/goose/skills/epinettes/SKILL.md
+++ b/sandboxes/goose/skills/epinettes/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: epinettes
+description: >-
+  Load at the start of every OpenShell sandbox session before other work.
+  OpenShell host ≥ 0.0.72. Filesystem layout, default-deny network policy,
+  dependency installs, and what to do when access is blocked. Use when curl or
+  a tool fails to connect, you see policy_denied, HTTP 000/403 from the proxy,
+  or you need to understand what this environment allows. Trigger keywords -
+  openshell, sandbox, policy, network blocked, policy_denied, policy.local,
+  connection refused, exit code 56.
+license: Apache-2.0
+metadata:
+  openshell_version: "0.0.72"
+  skill_version: "1"
+---
+
+# Épinettes
+
+You are **Goose**, running inside
+[OpenShell](https://github.com/NVIDIA/OpenShell) — an isolated sandbox runtime.
+OpenShell gates **outbound network access** and **filesystem writes** so agents
+can work safely. Treat denials as expected behavior, not bugs — then either use
+an already-allowed path or request a narrow policy change.
+
+If `/AGENTS.md` exists at the filesystem root, read it for Policy Advisor
+workflow. OpenShell creates it only when `agent_policy_proposals_enabled` is
+true — it is not present by default. If absent, use the sections below.
+
+## Version
+
+This skill targets OpenShell **≥ 0.0.72** on the host gateway. Older hosts
+lack MCP policy (`protocol: mcp`), reliable L7 denials, and other behavior
+assumed here.
+
+| Field | Value |
+|-------|-------|
+| Minimum OpenShell host | **≥ 0.0.72** (`metadata.openshell_version`) |
+| This skill document | **1** (`metadata.skill_version`) |
+
+The `version: 1` at the top of `/etc/openshell/policy.yaml` is the **policy
+schema** version, not the OpenShell runtime version.
+
+You usually **cannot** run `openshell --version` inside the sandbox. Ask the
+operator to check on the host:
+
+```bash
+openshell status      # includes Version
+openshell --version
+```
+
+If the host is **below 0.0.72**, tell the operator to upgrade OpenShell before
+continuing — do not guess at policy or MCP behavior on unsupported versions.
+
+If the host is **≥ 0.0.72** but behavior does not match this skill (missing
+`policy.local` routes, different denial JSON, new settings names), this skill
+may be **out of date**. Prefer
+[OpenShell docs](https://docs.nvidia.com/openshell/) and the
+[community skill source](https://github.com/NVIDIA/OpenShell-Community/tree/main/sandboxes/goose/skills/epinettes)
+over stale guidance here.
+
+## Goose
+
+| Item | Path or command |
+|------|-----------------|
+| Provider config | `/sandbox/.config/goose/config.yaml` |
+| Global hints | `/sandbox/.config/goose/.goosehints` |
+| First-time setup | `goose configure` |
+| Agent session | `goose session` |
+
+## Filesystem
+
+| Path | Access | Use for |
+|------|--------|---------|
+| `/sandbox` | read/write | Home directory, projects, caches, config |
+| `/tmp` | read/write | Temporary files |
+| `/usr`, `/etc`, `/lib`, … | read-only | System tools only — **cannot** `apt install` |
+
+- Run as user **`sandbox`**, not root.
+- Keep artifacts under `/sandbox` or the mounted workdir.
+- Python venv: `/sandbox/.venv` (`pip`, `uv pip install`).
+- Agent skills: `/sandbox/.agents/skills/`.
+
+## Network policy model
+
+Default deny. A connection is allowed only when **all** of these match an entry
+in the effective policy:
+
+1. **Binary** — the executable making the connection (e.g. `/usr/bin/curl`,
+   `/usr/local/bin/goose`)
+2. **Host and port** — destination (e.g. `api.github.com:443`)
+3. **L7 rules** (when `protocol: rest`, `mcp`, etc.) — HTTP method/path or MCP
+   method/tool for inspected HTTPS traffic
+
+MCP policy support (`protocol: mcp`) needs OpenShell **≥ 0.0.72** on the host.
+Remote Goose extensions (including `goose_mcp` rules in this image) will not
+work correctly on older hosts.
+
+This goose image ships its own policy at `/etc/openshell/policy.yaml` (LLM
+providers, GitHub, PyPI, npm, etc.). The operator may also pass a custom policy
+at create time.
+
+### Inspect what is allowed
+
+```bash
+# Static policy baked into the image
+cat /etc/openshell/policy.yaml
+
+# Live effective policy (when policy advisor is enabled)
+curl -s http://policy.local/v1/policy/current
+
+# Recent denials (when policy advisor is enabled)
+curl -s 'http://policy.local/v1/denials?last=10'
+```
+
+When `policy.local` returns `feature_disabled`, agent-facing policy APIs are
+probably off or prohibited. The image policy file is still authoritative for
+what is pre-allowed.
+
+## Typically pre-allowed
+
+Exact rules depend on the effective policy. This goose sandbox commonly allows:
+
+| Need | Binary | Endpoints |
+|------|--------|-----------|
+| Git clone/fetch (read) | `/usr/bin/git` | `github.com:443` |
+| GitHub REST (read-only) | `/usr/bin/gh` | `api.github.com:443` |
+| Python packages | `/sandbox/.venv/bin/pip`, `/usr/local/bin/uv` | `pypi.org`, … |
+| npm packages | `/usr/bin/node`, `/usr/local/bin/npm` | `registry.npmjs.org:443` |
+| Goose LLM providers | `/usr/local/bin/goose` | See `policy.yaml` `goose:` block |
+| Goose MCP extensions | `/usr/local/bin/goose` | See `goose_mcp:` in `policy.yaml` |
+
+**Do not assume** a host is reachable until you confirm it in the effective
+policy or a successful request.
+
+For GitHub operations, read `/sandbox/.agents/skills/github/SKILL.md` —
+GraphQL is blocked; prefer `gh api` REST paths.
+
+## Installing dependencies
+
+Prefer user-space installs into writable paths:
+
+```bash
+uv pip install <package>          # Python → /sandbox/.venv
+npm install <package>             # Node (project-local or global if allowed)
+```
+
+Avoid `apt-get` / `sudo` — system directories are read-only. To add system
+packages or other image changes, fork
+[OpenShell-Community](https://github.com/NVIDIA/OpenShell-Community), update the
+sandbox Dockerfile on a branch, rebuild the image, and contribute back if you
+want the change upstream.
+
+## When network access is blocked
+
+Symptoms: `curl: (56)`, HTTP `000`, connection errors, or a JSON body with
+`policy_denied`.
+
+1. **Read `/AGENTS.md`** when it exists — OpenShell writes it only with Policy
+   Advisor enabled (`agent_policy_proposals_enabled`).
+2. **Mechanistic drafts** — OpenShell auto-proposes a rule from the denial. The
+   **operator** approves via `openshell term` (sandbox → `r`) or
+   `openshell rule approve`. You cannot approve your own requests.
+3. **Agent proposals** — When `agent_policy_proposals_enabled` is true, read
+   the OpenShell policy advisor skill and documentation:
+   - `/etc/openshell/skills/policy-advisor/SKILL.md`
+   - `/etc/openshell/skills/policy_advisor.md`
+
+If agent proposals are disabled, tell the operator to enable
+`agent_policy_proposals_enabled` on the sandbox or gateway. A mechanistic
+pending rule may still appear for the same denial.
+
+Do **not** bypass policy (raw IPs, iptables, alternate DNS tricks, tunneling).
+
+## Credentials
+
+API keys and tokens are usually injected by the operator through OpenShell
+**providers**. Inside the sandbox you may see placeholder values in environment
+variables; the proxy resolves them on outbound requests. You do not receive
+real secrets in plaintext.
+
+If authentication fails despite network access being allowed, the operator may
+need to attach or configure a provider — that is outside your control.
+
+## Pre-installed tools
+
+From the base sandbox: `git`, `gh`, `curl`, `node`, `npm`, `python3`, `uv`,
+`pip`, and several coding-agent CLIs (`claude`, `opencode`, `codex`, `copilot`).
+This image adds **Goose** (`goose`).
+
+## OpenShell supervisor skills
+
+OpenShell installs runtime skills under `/etc/openshell/skills/`. These are
+**not** on the usual agent discovery path (`/sandbox/.agents/skills/`). Nothing
+loads them automatically — read them when `/AGENTS.md`, a denial, or the task
+points you there.
+
+When `agent_policy_proposals_enabled` is true, the supervisor typically
+installs:
+
+- `/etc/openshell/skills/policy-advisor/SKILL.md` — short entry point
+- `/etc/openshell/skills/policy_advisor.md` — full policy-advisor workflow
+
+L7 `policy_denied` responses may reference that path in `next_steps`. If you
+are unsure what is installed, list the directory:
+
+```bash
+ls /etc/openshell/skills/
+```
+
+## Related skills
+
+| Topic | Path |
+|-------|------|
+| Épinettes (this file) | `/sandbox/.agents/skills/epinettes/SKILL.md` |
+| GitHub in sandboxes | `/sandbox/.agents/skills/github/SKILL.md` |
+| Policy denials (supervisor) | `/etc/openshell/skills/policy-advisor/SKILL.md` |


### PR DESCRIPTION
Adds a new sandbox image pre-configured with [Goose](https://github.com/aaif-goose/goose) — the AAIF open-source AI agent CLI — for use inside OpenShell sandboxes.

## Changes

- **`sandboxes/goose/Dockerfile`** — Builds on the community base image; installs Goose (`GOOSE_VERSION=stable` by default, pin-able at build time); copies policy, hints, minimal config, and skills
- **`sandboxes/goose/policy.yaml`** — Goose LLM provider endpoints, `goose_mcp` block (Excalidraw MCP App starter), plus shared git/gh/pypi/npm policies
- **`sandboxes/goose/.goosehints`** — Global hints at `/sandbox/.config/goose/.goosehints` (session-start skill loading, OpenShell context)
- **`sandboxes/goose/skills/epinettes/`** — OpenShell-aware agent skill (filesystem, network policy, blocked-access workflow); targets OpenShell **≥ 0.0.72**
- **`sandboxes/goose/config.yaml`** — Baked default: telemetry disabled; provider/extensions are runtime config
- **`sandboxes/goose/README.md`** — Build, configuration, usage, and MCP extension notes
- **`README.md`** — Adds `sandboxes/goose/` to the sandboxes table

## Notes

- Remote MCP extensions (e.g. Excalidraw) need OpenShell **≥ 0.0.72** for `protocol: mcp` policy support.
- Goose-specific content lives in the goose image only; the base sandbox is unchanged.

## Test plan

Verified locally:

- [x] `docker build -t openshell-goose sandboxes/goose` (local base chain: `openshell-base` → `openshell-goose`)
- [x] `goose --version` inside the built image
- [x] `goose skills list` discovers `epinettes` and `github`
- [x] `goose session` with provider config via `--upload` (Ollama)
- [x] Excalidraw MCP extension via `--with-streamable-http-extension` + local test policy (tool traces in terminal; scene export needs valid Excalidraw file format)

For reviewers / CI:

- [ ] GitHub Actions `build-sandboxes` job on this PR
- [ ] End-to-end on OpenShell **≥ 0.0.72** gateway (MCP policy enforcement)