### PR TITLE
fix(policy): allow npm child process and Vertex AI egress for opencode

### DIFF
--- a/sandboxes/base/policy.yaml
+++ b/sandboxes/base/policy.yaml
@@ -177,12 +177,32 @@ network_policies:
       port: 443
     - host: opencode.ai
       port: 443
+    - host: models.opencode.ai
+      port: 443
     - host: integrate.api.nvidia.com
+      port: 443
+    # Google Vertex AI + token endpoints (mirrors gemini policy). sts is
+    # additionally required for GitHub-OIDC Workload Identity Federation.
+    - host: "*-aiplatform.googleapis.com"
+      port: 443
+    - host: sts.googleapis.com
+      port: 443
+    - host: oauth2.googleapis.com
+      port: 443
+    - host: www.googleapis.com
+      port: 443
+    - host: iamcredentials.googleapis.com
+      port: 443
+    - host: accounts.google.com
       port: 443
     binaries:
     - path: /usr/lib/node_modules/opencode-ai/bin/.opencode
     - path: /usr/bin/node
     - path: /usr/local/bin/opencode
+    # npm child process (background dependency install / arborist) connects
+    # as npm, not opencode/node, so it must be allowlisted explicitly.
+    - path: /usr/local/bin/npm
+    - path: /usr/bin/npm
 
   codex:
     name: codex

--- a/sandboxes/gemini/policy.yaml
+++ b/sandboxes/gemini/policy.yaml
@@ -160,12 +160,32 @@ network_policies:
         port: 443
       - host: opencode.ai
         port: 443
+      - host: models.opencode.ai
+        port: 443
       - host: integrate.api.nvidia.com
+        port: 443
+      # Google Vertex AI + token endpoints. sts is additionally required
+      # for GitHub-OIDC Workload Identity Federation.
+      - host: "*-aiplatform.googleapis.com"
+        port: 443
+      - host: sts.googleapis.com
+        port: 443
+      - host: oauth2.googleapis.com
+        port: 443
+      - host: www.googleapis.com
+        port: 443
+      - host: iamcredentials.googleapis.com
+        port: 443
+      - host: accounts.google.com
         port: 443
     binaries:
       - path: /usr/lib/node_modules/opencode-ai/bin/.opencode
       - path: /usr/bin/node
       - path: /usr/local/bin/opencode
+      # npm child process (background dependency install / arborist)
+      # connects as npm, not opencode/node, so allowlist it explicitly.
+      - path: /usr/local/bin/npm
+      - path: /usr/bin/npm
 
   copilot:
     name: copilot


### PR DESCRIPTION
Refs #91

## Summary

The `opencode` network policy (in both `sandboxes/base/policy.yaml` and `sandboxes/gemini/policy.yaml`) has two egress gaps that break real-world OpenCode usage. This PR fixes both, applied identically to the base and gemini sandbox policies.

### 1. npm installs fail with `ECONNRESET` (binary allowlist gap)

`registry.npmjs.org` is already allowlisted as an *endpoint*, but the `npm` binary is not in the policy's `binaries:` list. Policy pairs are `(binary, endpoint)`, so when opencode spawns a background `npm install` (arborist), the connecting process is `/usr/local/bin/npm` (or `/usr/bin/npm`) — not the allowlisted opencode/node binaries - and its CONNECT to `registry.npmjs.org` is denied.

This is **not** TLS-MITM: `registry.npmjs.org` is a plain CONNECT tunnel (no `tls: terminate`). It is purely a binary allowlist gap. The `droid` and `ollama` sandboxes already ship dedicated `npm` policies; `opencode` never allowlisted npm.

**Fix:** add `/usr/local/bin/npm` and `/usr/bin/npm` to the `binaries:` allowlist.

### 2. No Google / Vertex AI egress

The `opencode` policy had zero Google hosts, so running OpenCode against a `google-vertex-*` provider (Vertex AI, including GitHub-OIDC Workload Identity Federation) could not reach the required Google endpoints - both token exchange and inference fail.

**Fix:** add the Vertex AI + Google token hosts (mirroring the `gemini` policy) plus `sts.googleapis.com`, which GitHub-OIDC WIF additionally requires for token exchange. Also add `models.opencode.ai` so opencode does not silently fall back to its built-in default model.

## Changes

- `*-aiplatform.googleapis.com`, `sts.googleapis.com`, `oauth2.googleapis.com`,`www.googleapis.com`, `iamcredentials.googleapis.com`, `accounts.google.com` added to endpoints
- `models.opencode.ai` added to endpoints
- `/usr/local/bin/npm`, `/usr/bin/npm` added to binaries

## Environment

- Base image: `nvcr.io/nvidia/base/ubuntu:noble-20251013` (Ubuntu 24.04)
- Node `22.22.1-1nodesource1`, npm `11.11.0`, `opencode-ai@1.2.18` (global)

## Testing

- `python3 -c "import yaml; yaml.safe_load(...)"` passes for both files.