### PR TITLE
fix(policy): allow credentialed L4 GitHub endpoints in default policies

### DIFF
--- a/sandboxes/base/policy.yaml
+++ b/sandboxes/base/policy.yaml
@@ -101,8 +101,8 @@ network_policies:
     name: copilot
     endpoints:
       # Auth and user management
-      - { host: github.com, port: 443 }
-      - { host: api.github.com, port: 443 }
+      - { host: github.com, port: 443, allow_uninspected_credentials: true }
+      - { host: api.github.com, port: 443, allow_uninspected_credentials: true }
       # Copilot API (subscription-tier routing)
       - { host: api.githubcopilot.com, port: 443, protocol: rest, enforcement: enforce, access: read-write }
       - { host: api.individual.githubcopilot.com, port: 443, protocol: rest, enforcement: enforce, access: read-write }
@@ -125,10 +125,10 @@ network_policies:
       - { host: pypi.org, port: 443 }
       - { host: files.pythonhosted.org, port: 443 }
       # uv python install downloads from python-build-standalone on GitHub
-      - { host: github.com, port: 443 }
+      - { host: github.com, port: 443, allow_uninspected_credentials: true }
       - { host: objects.githubusercontent.com, port: 443 }
       # uv resolves python-build-standalone release metadata via the GitHub API
-      - { host: api.github.com, port: 443 }
+      - { host: api.github.com, port: 443, allow_uninspected_credentials: true }
       - { host: downloads.python.org, port: 443 }
     binaries:
       - { path: /sandbox/.venv/bin/python }

--- a/sandboxes/droid/policy.yaml
+++ b/sandboxes/droid/policy.yaml
@@ -126,9 +126,9 @@ network_policies:
     endpoints:
       - { host: pypi.org, port: 443 }
       - { host: files.pythonhosted.org, port: 443 }
-      - { host: github.com, port: 443 }
+      - { host: github.com, port: 443, allow_uninspected_credentials: true }
       - { host: objects.githubusercontent.com, port: 443 }
-      - { host: api.github.com, port: 443 }
+      - { host: api.github.com, port: 443, allow_uninspected_credentials: true }
       - { host: downloads.python.org, port: 443 }
     binaries:
       - { path: /sandbox/.venv/bin/python }

--- a/sandboxes/gemini/policy.yaml
+++ b/sandboxes/gemini/policy.yaml
@@ -108,10 +108,10 @@ network_policies:
       - { host: pypi.org, port: 443 }
       - { host: files.pythonhosted.org, port: 443 }
       # uv python install downloads from python-build-standalone on GitHub
-      - { host: github.com, port: 443 }
+      - { host: github.com, port: 443, allow_uninspected_credentials: true }
       - { host: objects.githubusercontent.com, port: 443 }
       # uv resolves python-build-standalone release metadata via the GitHub API
-      - { host: api.github.com, port: 443 }
+      - { host: api.github.com, port: 443, allow_uninspected_credentials: true }
       - { host: downloads.python.org, port: 443 }
     binaries:
       - { path: /sandbox/.venv/bin/python }
@@ -170,8 +170,8 @@ network_policies:
   copilot:
     name: copilot
     endpoints:
-      - { host: github.com, port: 443 }
-      - { host: api.github.com, port: 443 }
+      - { host: github.com, port: 443, allow_uninspected_credentials: true }
+      - { host: api.github.com, port: 443, allow_uninspected_credentials: true }
       - { host: api.githubcopilot.com, port: 443 }
       - { host: api.enterprise.githubcopilot.com, port: 443 }
       - { host: release-assets.githubusercontent.com, port: 443 }

--- a/sandboxes/ollama/policy.yaml
+++ b/sandboxes/ollama/policy.yaml
@@ -42,7 +42,7 @@ network_policies:
       - { host: registry.ollama.com, port: 443 }
       - { host: registry.ollama.ai, port: 443 }
       - { host: "*.r2.cloudflarestorage.com", port: 443 }
-      - { host: github.com, port: 443 }
+      - { host: github.com, port: 443, allow_uninspected_credentials: true }
       - { host: objects.githubusercontent.com, port: 443 }
       - { host: raw.githubusercontent.com, port: 443 }
       - { host: release-assets.githubusercontent.com, port: 443 }

--- a/sandboxes/pi/policy.yaml
+++ b/sandboxes/pi/policy.yaml
@@ -75,8 +75,8 @@ network_policies:
       - { host: platform.claude.com, port: 443 }
       - { host: auth.openai.com, port: 443 }
       - { host: chatgpt.com, port: 443 }
-      - { host: github.com, port: 443 }
-      - { host: api.github.com, port: 443 }
+      - { host: github.com, port: 443, allow_uninspected_credentials: true }
+      - { host: api.github.com, port: 443, allow_uninspected_credentials: true }
       # pi downloads managed fd/ripgrep binaries from GitHub release assets.
       - { host: release-assets.githubusercontent.com, port: 443 }
       - { host: api.githubcopilot.com, port: 443 }
@@ -145,10 +145,10 @@ network_policies:
       - { host: pypi.org, port: 443 }
       - { host: files.pythonhosted.org, port: 443 }
       # uv python install downloads from python-build-standalone on GitHub
-      - { host: github.com, port: 443 }
+      - { host: github.com, port: 443, allow_uninspected_credentials: true }
       - { host: objects.githubusercontent.com, port: 443 }
       # uv resolves python-build-standalone release metadata via the GitHub API
-      - { host: api.github.com, port: 443 }
+      - { host: api.github.com, port: 443, allow_uninspected_credentials: true }
       - { host: downloads.python.org, port: 443 }
     binaries:
       - { path: /sandbox/.venv/bin/python }


### PR DESCRIPTION
## What

Mark the plain L4 `github.com` and `api.github.com` endpoints in the default sandbox policies as `allow_uninspected_credentials: true`.

Affected policies: `base`, `droid`, `gemini`, `pi`, `ollama`.

## Why

These policies list `github.com` / `api.github.com` as plain L4 (uninspected) endpoints in rules such as `pypi`, `copilot`, and the agent rules. On their own that is fine. But when a **GitHub credential provider** is attached to a sandbox, the gateway marks every endpoint that reaches a credentialed host as a *credentialed endpoint* and rejects any that are L4-only (to stop an injected token leaking over an uninspected connection).

The result: on a provider-backed sandbox, **any** `openshell policy set` or `openshell policy update` fails — even when the change is unrelated to GitHub — with:

```
credentialed endpoint 'github.com:443' in rule 'pypi' uses L4-only; configure L7 inspection or explicitly set allow_uninspected_credentials: true
```

This is the root cause behind NVIDIA/OpenShell#2998 for users who create a sandbox with a GitHub provider on the default policy.

## Approach

These endpoints are intentionally uninspected — `uv` downloading `python-build-standalone` release assets, Copilot auth/user management, and agent binaries fetching updates from GitHub release assets. Setting `allow_uninspected_credentials: true` makes that intent explicit and restores the policies' behavior on provider-backed sandboxes, without changing anything for sandboxes that have no provider attached.

A more restrictive alternative would be to convert each endpoint to L7-inspected rules, but the affected rules bind to binaries (uv/python, copilot, agents) whose GitHub flows include `POST` (e.g. Copilot device-auth) and non-REST traffic, so an L7 read-only rule would break them. The explicit opt-in is the lowest-risk, behavior-preserving fix; maintainers can tighten specific endpoints to L7 later.

## Testing

- `python3 -c "import yaml; yaml.safe_load(...)"` on all five policies — valid.
- No other endpoints or rules changed; license headers untouched.

Related: NVIDIA/OpenShell#2998